### PR TITLE
Add XYZ_PROTOCOL_USE_REFLECTION cmake option to gate the reflection backend (4/20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,14 @@ option(ENABLE_TSAN "Enable Thread Sanitizer" OFF)
 option(ENABLE_MSAN "Enable Memory Sanitizer" OFF)
 
 option(
-  XYZ_PROTOCOL_BUILD_REFLECTION_TUTORIAL
-  "Also build and test tutorials/3_reflection.cc, which requires a compiler \
-with C++26 P2996 reflection support (GCC 16+ with -freflection)."
+  XYZ_PROTOCOL_USE_REFLECTION
+  "Build and test the C++26-reflection backend for xyz::protocol/ \
+xyz::protocol_view (protocol_reflection.h) and its teaching tutorial \
+(tutorials/3_reflection.cc), which require a compiler with C++26 P2996 \
+reflection support (GCC 16+ with -freflection)."
   OFF)
 
-if(XYZ_PROTOCOL_BUILD_REFLECTION_TUTORIAL)
+if(XYZ_PROTOCOL_USE_REFLECTION)
   include(CheckCXXSourceCompiles)
   set(CMAKE_REQUIRED_FLAGS "-std=c++26 -freflection")
   check_cxx_source_compiles(
@@ -49,7 +51,7 @@ if(XYZ_PROTOCOL_BUILD_REFLECTION_TUTORIAL)
   if(NOT XYZ_PROTOCOL_REFLECTION_SUPPORTED)
     message(
       FATAL_ERROR
-        "XYZ_PROTOCOL_BUILD_REFLECTION_TUTORIAL is ON but the compiler "
+        "XYZ_PROTOCOL_USE_REFLECTION is ON but the compiler "
         "(${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}) does not "
         "accept '-std=c++26 -freflection'. C++26 reflection currently "
         "requires GCC 16 or newer; configure with e.g. "
@@ -190,7 +192,7 @@ if(XYZ_PROTOCOL_IS_NOT_SUBPROJECT)
       FILES
       tutorials/2_vanishing_this_pointer.cc)
 
-    if(XYZ_PROTOCOL_BUILD_REFLECTION_TUTORIAL)
+    if(XYZ_PROTOCOL_USE_REFLECTION)
       xyz_add_test(
         NAME
         reflection_tutorial

--- a/scripts/cmake.py
+++ b/scripts/cmake.py
@@ -81,8 +81,7 @@ def main() -> None:
         f"-DENABLE_UBSAN={'ON' if args.ubsan else 'OFF'}",
         f"-DENABLE_TSAN={'ON' if args.tsan else 'OFF'}",
         f"-DENABLE_MSAN={'ON' if args.msan else 'OFF'}",
-        "-DXYZ_PROTOCOL_BUILD_REFLECTION_TUTORIAL="
-        + ("ON" if args.reflection else "OFF"),
+        "-DXYZ_PROTOCOL_USE_REFLECTION=" + ("ON" if args.reflection else "OFF"),
     ]
     if args.build_dir:
         configure_args.extend(["-B", args.build_dir])
@@ -92,7 +91,7 @@ def main() -> None:
     configure_args.extend(extra)
 
     # A P2996 reflection compiler is required to configure with
-    # XYZ_PROTOCOL_BUILD_REFLECTION_TUTORIAL=ON. CMake only reads CXX/CC
+    # XYZ_PROTOCOL_USE_REFLECTION=ON. CMake only reads CXX/CC
     # from the environment, not from -D cache variables, so set them here
     # rather than as configure_args.
     configure_env = os.environ.copy()


### PR DESCRIPTION
Reuses the existing GCC16+/-freflection toolchain probe rather than
adding a second option, since the new protocol_reflection.h backend
needs the same compiler as the tutorial. Named USE_REFLECTION from
the start rather than introduced as BUILD_REFLECTION_TUTORIAL and
renamed, since it gates the backend's own targets too, not just the
tutorial; no new targets yet.

