### PR TITLE
Add thunk.hxx: erased_call_thunk calling a pre-merged candidate type (9/20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,9 @@ if(XYZ_PROTOCOL_IS_NOT_SUBPROJECT)
         protocol_reflection_detail/types.hxx
         protocol_reflection_detail/types_test.cc
         protocol_reflection_detail/vtable_layout.hxx
-        protocol_reflection_detail/vtable_layout_test.cc)
+        protocol_reflection_detail/vtable_layout_test.cc
+        protocol_reflection_detail/thunk.hxx
+        protocol_reflection_detail/thunk_test.cc)
       target_compile_options(protocol_reflection_detail_test
                              PRIVATE -freflection)
       target_include_directories(protocol_reflection_detail_test

--- a/protocol_reflection_detail/thunk.hxx
+++ b/protocol_reflection_detail/thunk.hxx
@@ -1,0 +1,55 @@
+/* Copyright (c) 2025 The XYZ Protocol Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+// The static function stored in a vtable entry: casts the erased pointer
+// back to Implementation and forwards the call through MergedCandidates, a
+// default-constructible callable invoked as
+// MergedCandidates{}(implementation_reference, args...). This thunk only
+// requires MergedCandidates to be callable that way, so it can be tested
+// here against a hand-rolled fake candidate.
+#ifndef XYZ_PROTOCOL_REFLECTION_DETAIL_THUNK_HXX_
+#define XYZ_PROTOCOL_REFLECTION_DETAIL_THUNK_HXX_
+
+#include <type_traits>
+#include <utility>
+
+namespace xyz::reflection_detail {
+
+template <typename Implementation, typename MergedCandidates,
+          typename Signature, bool ConstErased, bool IsNoexcept>
+struct erased_call_thunk;
+
+template <typename Implementation, typename MergedCandidates, typename R,
+          typename... Args, bool ConstErased, bool IsNoexcept>
+struct erased_call_thunk<Implementation, MergedCandidates, R(Args...),
+                         ConstErased, IsNoexcept> {
+  using erased_pointer_type =
+      std::conditional_t<ConstErased, const void*, void*>;
+  using implementation_pointer_type =
+      std::conditional_t<ConstErased, const Implementation*, Implementation*>;
+
+  static R call(erased_pointer_type erased, Args... args) noexcept(IsNoexcept) {
+    auto* implementation = static_cast<implementation_pointer_type>(erased);
+    return MergedCandidates{}(*implementation, std::forward<Args>(args)...);
+  }
+};
+
+}  // namespace xyz::reflection_detail
+
+#endif  // XYZ_PROTOCOL_REFLECTION_DETAIL_THUNK_HXX_

--- a/protocol_reflection_detail/thunk_test.cc
+++ b/protocol_reflection_detail/thunk_test.cc
@@ -1,0 +1,71 @@
+/* Copyright (c) 2025 The XYZ Protocol Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+#include "protocol_reflection_detail/thunk.hxx"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using xyz::reflection_detail::erased_call_thunk;
+
+struct Implementation {
+  int value = 0;
+
+  int get() const { return value; }
+
+  void set(int v) { value = v; }
+};
+
+// Hand-rolled fake candidates: each is just a default-constructible callable
+// taking the implementation reference plus the call's own arguments.
+struct GetCandidate {
+  int operator()(const Implementation& impl) const { return impl.get(); }
+};
+
+struct SetCandidate {
+  void operator()(Implementation& impl, int v) const { impl.set(v); }
+};
+
+TEST(ErasedCallThunk, ConstErasedCallRoundTripsTheReturnValue) {
+  Implementation impl{.value = 42};
+  using Thunk =
+      erased_call_thunk<Implementation, GetCandidate, int(), true, false>;
+  EXPECT_EQ(Thunk::call(&impl), 42);
+}
+
+TEST(ErasedCallThunk, NonConstErasedCallForwardsArgumentsAndMutates) {
+  Implementation impl;
+  using Thunk =
+      erased_call_thunk<Implementation, SetCandidate, void(int), false, false>;
+  Thunk::call(&impl, 7);
+  EXPECT_EQ(impl.value, 7);
+}
+
+TEST(ErasedCallThunk,
+     IsNoexceptTemplateParameterControlsTheThunksNoexceptness) {
+  using NoexceptThunk =
+      erased_call_thunk<Implementation, GetCandidate, int(), true, true>;
+  using ThrowingThunk =
+      erased_call_thunk<Implementation, GetCandidate, int(), true, false>;
+  static_assert(noexcept(NoexceptThunk::call(nullptr)));
+  static_assert(!noexcept(ThrowingThunk::call(nullptr)));
+}
+
+}  // namespace


### PR DESCRIPTION
erased_call_thunk::call casts the erased pointer back to
Implementation and forwards to MergedCandidates{}(implementation,
args...); how candidates get merged is conformance.hxx's job, so this
is tested standalone against a fake candidate.

