### PR TITLE
Add protocol_view<T> and protocol_view<const T> (18/20)

### DIFF
--- a/protocol_reflection.hxx
+++ b/protocol_reflection.hxx
@@ -17,17 +17,16 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ==============================================================================*/
-// The C++26-reflection backend: a single xyz::protocol<T, Allocator> class
-// template body that works for any interface satisfying
-// reflection_protocol_concept, with no per-interface code generation step.
-//
-// Allocator-aware construction, copy/move/destroy/swap, and dispatch, one
-// interface at a time. No narrowing conversions between protocol<T,...>
-// specializations yet. xyz::protocol_view is out of scope here; it is
-// added once dispatch is proven.
+// The C++26-reflection backend: single xyz::protocol<T, Allocator> and
+// xyz::protocol_view<T>/protocol_view<const T> class templates that work
+// for any interface satisfying reflection_protocol_concept, with no
+// per-interface code generation step. Allocator-aware construction,
+// copy/move/destroy/swap, dispatch, and narrowing conversions between
+// protocol<T,...>/protocol_view<T> specializations.
 #ifndef XYZ_PROTOCOL_REFLECTION_HXX_
 #define XYZ_PROTOCOL_REFLECTION_HXX_
 
+#include <cassert>
 #include <memory>
 #include <meta>
 #include <utility>
@@ -58,6 +57,23 @@ consteval std::vector<std::meta::info> members_named_like(
     }
   }
   return result;
+}
+
+// The first *const* member sharing `member`'s name: the const view's
+// representative for a name-group, which can differ from
+// members_named_like(...)[0] when a group mixes const and non-const
+// overloads. Every const sibling recomputes this identically, the
+// invariant protocol_const_view_bases_type relies on to agree on one
+// representative per const name-group, the same way protocol_bases_type
+// relies on members_named_like(...)[0] for the unfiltered case.
+consteval std::meta::info first_const_member_named_like(
+    std::meta::info interface, std::meta::info member) {
+  for (std::meta::info sibling : members_named_like(interface, member)) {
+    if (std::meta::is_const(sibling)) {
+      return sibling;
+    }
+  }
+  throw std::meta::exception("no const sibling", ^^void);
 }
 
 // A concrete, non-generic forwarder for one interface overload: its
@@ -141,41 +157,316 @@ consteval std::meta::info protocol_bases_type() {
 template <typename Interface, typename Allocator>
 using protocol_bases = typename[:protocol_bases_type<Interface, Allocator>():];
 
+// protocol_view<Interface>/protocol_view<const Interface>'s own forwarder
+// machinery: the same shape as protocol_single_overload_wrapper/
+// protocol_member_wrapper_type/protocol_bases_type above, generalized to a
+// different Owner shape. protocol_view has no Allocator, dispatches
+// through vptr_/ptr_ instead of vtable_/p_, and (for the const view)
+// exposes only const overloads. protocol_member_wrapper_combinator's
+// merge-via-inheritance is Owner-agnostic, and reused as-is for both.
+
+// Mutable protocol_view<Interface>: every member, dispatched through
+// void*, exactly like protocol<Interface, Allocator>'s own entries.
+template <typename Interface, std::meta::info Member, typename R,
+          typename... Ps>
+struct protocol_view_single_overload_wrapper {
+  R operator()(Ps... ps) const noexcept(std::meta::is_noexcept(Member));
+};
+
+consteval std::meta::info protocol_view_member_wrapper_type(
+    std::meta::info interface, std::meta::info member) {
+  std::vector<std::meta::info> base_types;
+  for (std::meta::info sibling : members_named_like(interface, member)) {
+    std::vector<std::meta::info> args{
+        interface, std::meta::reflect_constant(sibling),
+        std::meta::dealias(std::meta::return_type_of(sibling))};
+    for (std::meta::info parameter_type : parameter_types_of(sibling)) {
+      args.push_back(parameter_type);
+    }
+    base_types.push_back(
+        std::meta::substitute(^^protocol_view_single_overload_wrapper, args));
+  }
+  return std::meta::substitute(^^protocol_member_wrapper_combinator,
+                               base_types);
+}
+
+template <typename Interface, std::meta::info Member>
+using protocol_view_member_wrapper =
+    typename[:protocol_view_member_wrapper_type(^^Interface, Member):];
+
+template <typename Interface>
+consteval std::meta::info protocol_view_bases_type() {
+  std::vector<std::meta::info> bases;
+  for (std::meta::info member : interface_member_functions(^^Interface)) {
+    std::meta::info representative = members_named_like(^^Interface, member)[0];
+    if (representative != member) {
+      continue;
+    }
+    std::meta::info wrapper_type =
+        protocol_view_member_wrapper_type(^^Interface, member);
+    bases.push_back(std::meta::substitute(
+        ^^forwarder_base,
+        {
+            wrapper_type, std::meta::reflect_constant(representative)}));
+  }
+  return forwarders_type(bases);
+}
+
+template <typename Interface>
+using protocol_view_bases = typename[:protocol_view_bases_type<Interface>():];
+
+// protocol_view<const Interface>: const members only, dispatched through
+// const void*.
+template <typename Interface, std::meta::info Member, typename R,
+          typename... Ps>
+struct protocol_const_view_single_overload_wrapper {
+  R operator()(Ps... ps) const noexcept(std::meta::is_noexcept(Member));
+};
+
+consteval std::meta::info protocol_const_view_member_wrapper_type(
+    std::meta::info interface, std::meta::info member) {
+  std::vector<std::meta::info> base_types;
+  for (std::meta::info sibling : members_named_like(interface, member)) {
+    if (!std::meta::is_const(sibling)) {
+      continue;
+    }
+    std::vector<std::meta::info> args{
+        interface, std::meta::reflect_constant(sibling),
+        std::meta::dealias(std::meta::return_type_of(sibling))};
+    for (std::meta::info parameter_type : parameter_types_of(sibling)) {
+      args.push_back(parameter_type);
+    }
+    base_types.push_back(std::meta::substitute(
+        ^^protocol_const_view_single_overload_wrapper, args));
+  }
+  return std::meta::substitute(^^protocol_member_wrapper_combinator,
+                               base_types);
+}
+
+template <typename Interface, std::meta::info Member>
+using protocol_const_view_member_wrapper =
+    typename[:protocol_const_view_member_wrapper_type(^^Interface, Member):];
+
+template <typename Interface>
+consteval std::meta::info protocol_const_view_bases_type() {
+  std::vector<std::meta::info> bases;
+  for (std::meta::info member : interface_member_functions(^^Interface)) {
+    if (!std::meta::is_const(member)) {
+      continue;
+    }
+    std::meta::info representative =
+        first_const_member_named_like(^^Interface, member);
+    if (representative != member) {
+      continue;
+    }
+    std::meta::info wrapper_type =
+        protocol_const_view_member_wrapper_type(^^Interface, member);
+    bases.push_back(std::meta::substitute(
+        ^^forwarder_base,
+        {
+            wrapper_type, std::meta::reflect_constant(representative)}));
+  }
+  return forwarders_type(bases);
+}
+
+template <typename Interface>
+using protocol_const_view_bases =
+    typename[:protocol_const_view_bases_type<Interface>():];
+
+// Populates a const_view_vtable<Interface>/view_vtable<Interface>
+// (vtable_layout.hxx) for one implementation, dispatch entry by dispatch
+// entry: the read-only (protocol_view<const T>) and read-write
+// (protocol_view<T>) counterparts of protocol<T, Allocator>'s own vtable
+// population above, using the same template-for + thunk.hxx/conformance.hxx
+// pattern.
+template <typename Interface, typename Implementation>
+consteval const_view_vtable<Interface> build_const_view_vtable() {
+  using ConstViewVtable = const_view_vtable<Interface>;
+  ConstViewVtable vt{};
+  template for (constexpr std::meta::info member : std::define_static_array(
+                    interface_member_functions(^^Interface))) {
+    if constexpr (std::meta::is_const(member)) {
+      constexpr std::meta::info entry =
+          find_data_member(^^ConstViewVtable, vtable_slot_name(member));
+      constexpr std::meta::info merged_type = candidate_overload_set_type(
+          resolve_implementation_candidates(member, ^^Implementation),
+          ^^const Implementation&);
+      using Thunk = erased_call_thunk<
+          Implementation,
+          typename[:merged_type:], typename
+                    [:member_function_type(
+                          member):], true, std::meta::is_noexcept(member)>;
+      vt.[:entry:] = &Thunk::call;
+    }
+  }
+  return vt;
+}
+
+template <typename Interface, typename Implementation>
+inline constexpr const_view_vtable<Interface> const_view_vtable_for =
+    build_const_view_vtable<Interface, Implementation>();
+
+template <typename Interface, typename Implementation>
+consteval view_vtable<Interface> build_view_vtable() {
+  using ViewVtable = view_vtable<Interface>;
+  ViewVtable vt{};
+  vt.const_view = const_view_vtable_for<Interface, Implementation>;
+  template for (constexpr std::meta::info member : std::define_static_array(
+                    interface_member_functions(^^Interface))) {
+    constexpr std::meta::info entry =
+        find_data_member(^^ViewVtable, vtable_slot_name(member));
+    constexpr std::meta::info merged_type = candidate_overload_set_type(
+        resolve_implementation_candidates(member, ^^Implementation),
+        ^^Implementation&);
+    using Thunk = erased_call_thunk<
+        Implementation, typename[:merged_type:], typename[:member_function_type(
+                                                               member):
+    ], false, std::meta::is_noexcept(member)>;
+    vt.[:entry:] = &Thunk::call;
+  }
+  return vt;
+}
+
+template <typename Interface, typename Implementation>
+inline constexpr view_vtable<Interface> view_vtable_for =
+    build_view_vtable<Interface, Implementation>();
+
+// Copies every data member `to` has from the same-named member of `from`.
+// The shared implementation behind every map_*_vtable_members overload
+// below: each vtable shape (owning, const-view, view) differs only in
+// which fields it has, not in how narrowing one to another works.
+template <typename FromVtable, typename ToVtable>
+void copy_matching_by_name(const FromVtable* from, ToVtable* to) {
+  template for (constexpr std::meta::info to_member :
+                std::define_static_array(std::meta::nonstatic_data_members_of(
+                    ^^ToVtable, std::meta::access_context::current()))) {
+    constexpr std::string_view name = std::meta::identifier_of(to_member);
+    constexpr std::meta::info from_member =
+        find_data_member(^^FromVtable, name);
+    to->[:to_member:] = from->[:from_member:];
+  }
+}
+
+// const_view_vtable<Interface> and view_vtable<Interface> (vtable_layout.hxx)
+// are local classes, declared inside make_const_view_vtable_info and
+// make_view_vtable_info in this namespace.
+//
+// A function-local class's namespace for ADL is the namespace of the
+// function that declares it, not the enclosing namespace. That's different
+// from protocol<T,Allocator>::vtable, a member class of protocol, whose
+// associated namespace is xyz directly.
+//
+// protocol.h's get_const_vtable/get_vtable call these two unqualified and
+// rely on ADL, so they must live here, in xyz::reflection_detail, to be
+// found. map_owning_vtable_members has no such restriction and correctly
+// lives in xyz instead. Moving these two into xyz produces "not declared in
+// this scope, and no declarations were found by argument-dependent lookup."
+
+// const_view_vtable<Interface> is flat, so narrowing it is exactly
+// copy_matching_by_name.
+template <typename FromVtable, typename ToVtable>
+void map_const_vtable_members(const FromVtable* from, ToVtable* to) {
+  copy_matching_by_name(from, to);
+}
+
+// view_vtable<Interface> additionally has a const_view sub-object: narrowed
+// the same way, recursively, then every other (non-const_view) entry is
+// narrowed like the owning vtable.
+template <typename FromVtable, typename ToVtable>
+void map_vtable_members(const FromVtable* from, ToVtable* to) {
+  map_const_vtable_members(&from->const_view, &to->const_view);
+  template for (constexpr std::meta::info to_member :
+                std::define_static_array(std::meta::nonstatic_data_members_of(
+                    ^^ToVtable, std::meta::access_context::current()))) {
+    constexpr std::string_view name = std::meta::identifier_of(to_member);
+    if constexpr (name != "const_view") {
+      constexpr std::meta::info from_member =
+          find_data_member(^^FromVtable, name);
+      to->[:to_member:] = from->[:from_member:];
+    }
+  }
+}
+
 }  // namespace reflection_detail
 
-// protocol<Interface, Allocator>'s own nested vtable already is the owning
-// vtable used for narrowing; this trait just names it the way
-// protocol.h's get_owning_vtable expects, matching how the Python/libclang
-// backend's own generated protocol_owning_vtable_traits<::xyz::A,
-// Allocator> is a bare alias to protocol<::xyz::A, Allocator>::vtable, not
-// a separately-designed type.
+// protocol<Interface, Allocator>'s own nested vtable is already the owning
+// vtable used for narrowing. This trait just names it the way protocol.h's
+// get_owning_vtable expects, matching how the Python/libclang backend's
+// generated protocol_owning_vtable_traits<::xyz::A, Allocator> is a bare
+// alias to protocol<::xyz::A, Allocator>::vtable, not a separately-designed
+// type.
 template <typename Interface, typename Allocator>
 struct protocol_owning_vtable_traits {
   using vtable = typename protocol<Interface, Allocator>::vtable;
 };
 
-// Narrows a source owning vtable to a target one by copying every entry
-// the target has (by exact name -- including xyz_protocol_clone/_move/
-// _destroy, which every protocol's own vtable always declares) from the
-// matching entry in the source. FromVtable/ToVtable are deduced directly
-// from the pointer arguments, not from an Interface/Allocator template
-// argument list: unlike the Python/libclang backend, where a per-interface
-// generated overload hardcodes its own target type, this one generic
-// definition works for any (FromInterface, ToInterface, Allocator), since
-// it reflects on the two concrete vtable struct types themselves rather
-// than needing to know which interfaces they came from. Found via ADL
-// from get_owning_vtable (protocol.h): FromVtable/ToVtable are nested
-// types of xyz::protocol<...>, so this must live in namespace xyz, not
-// xyz::reflection_detail, to be visible there.
+// protocol_view<T>/protocol_view<const T>'s narrowing counterpart to
+// protocol_owning_vtable_traits above, used by protocol.h's
+// get_const_vtable/get_vtable.
+template <typename Interface>
+struct protocol_vtable_traits {
+  using const_vtable = reflection_detail::const_view_vtable<Interface>;
+  using vtable = reflection_detail::view_vtable<Interface>;
+};
+
+namespace reflection_detail {
+
+// Narrows a view_vtable<FromInterface>* to a view_vtable<ToInterface>*
+// (protocol<T,Allocator>'s own view_vt field), using the same cached-mapping
+// mechanism get_vtable (protocol.h) uses. It's keyed directly off the
+// concrete FromViewVtable/ToViewVtable types deduced from view_vt's own
+// pointer type, since a vtable struct here carries no Interface type of its
+// own to look protocol_vtable_traits<Interface> up by.
+template <typename FromViewVtable, typename ToViewVtable>
+const ToViewVtable* narrow_view_vtable_pointer(const FromViewVtable* source) {
+  static const char conversion_anchor = 0;
+  auto mapping_function = [](const void* from, void* to) {
+    map_vtable_members(static_cast<const FromViewVtable*>(from),
+                       static_cast<ToViewVtable*>(to));
+  };
+  return static_cast<const ToViewVtable*>(get_mapped_vtable(
+      source, &conversion_anchor, sizeof(ToViewVtable), mapping_function));
+}
+
+}  // namespace reflection_detail
+
+// Narrows a source owning vtable to a target one by copying every entry the
+// target has, by exact name, from the matching entry in the source. That
+// includes xyz_protocol_clone/_move/_destroy, which every protocol's own
+// vtable declares.
+//
+// The exception is view_vt (protocol<T,Allocator>'s own vtable field): it
+// points to a different view_vtable<Interface> per Interface, so it needs
+// its own recursive narrowing instead of a same-type copy.
+//
+// FromVtable and ToVtable are deduced directly from the pointer arguments,
+// not from an Interface/Allocator template argument list. The Python/
+// libclang backend instead generates one hardcoded overload per interface
+// pair; this single generic definition works for any (FromInterface,
+// ToInterface, Allocator) because it operates on the two concrete vtable
+// struct types directly, without needing to know which interfaces they
+// came from.
+//
+// get_owning_vtable (protocol.h) finds this function via ADL: FromVtable
+// and ToVtable are nested types of xyz::protocol<...>, so this function
+// must live in namespace xyz, not xyz::reflection_detail, to be visible
+// there.
 template <typename FromVtable, typename ToVtable>
 void map_owning_vtable_members(const FromVtable* from, ToVtable* to) {
   template for (constexpr std::meta::info to_member :
                 std::define_static_array(std::meta::nonstatic_data_members_of(
                     ^^ToVtable, std::meta::access_context::current()))) {
     constexpr std::string_view name = std::meta::identifier_of(to_member);
-    constexpr std::meta::info from_member =
-        reflection_detail::find_data_member(^^FromVtable, name);
-    to->[:to_member:] = from->[:from_member:];
+    if constexpr (name == "view_vt") {
+      to->view_vt = reflection_detail::narrow_view_vtable_pointer<
+          std::remove_const_t<std::remove_pointer_t<decltype(from->view_vt)>>,
+          std::remove_const_t<std::remove_pointer_t<decltype(to->view_vt)>>>(
+          from->view_vt);
+    } else {
+      constexpr std::meta::info from_member =
+          reflection_detail::find_data_member(^^FromVtable, name);
+      to->[:to_member:] = from->[:from_member:];
+    }
   }
 }
 
@@ -185,15 +476,20 @@ class protocol : public reflection_detail::protocol_bases<T, Allocator> {
   friend struct reflection_detail::protocol_single_overload_wrapper;
   template <typename, typename>
   friend class protocol;
+  friend class protocol_view<T>;
+  friend class protocol_view<const T>;
 
   using clone_or_move_fn = void* (*)(void*, const Allocator&);
   using destroy_fn = void (*)(void*, const Allocator&);
+  using view_vtable_ptr = const reflection_detail::view_vtable<T>*;
 
-  // protocol's own vtable: clone/move/destroy, plus one entry per
-  // interface member, all erased through void* (never const void*).
-  // The owning object itself provides both const and non-const access
-  // paths, so a single erased pointer kind suffices here, unlike
-  // vtable_layout.hxx's view_vtable/const_view_vtable split.
+  // protocol's own vtable: clone/move/destroy, a pointer to the
+  // allocator-independent shape vtable protocol_view narrows against
+  // (view_vt), plus one entry per interface member, all erased through
+  // void* (never const void*). The owning object itself provides both
+  // const and non-const access paths, so a single erased pointer kind
+  // suffices for its own entries, unlike vtable_layout.hxx's
+  // view_vtable/const_view_vtable split that view_vt points to.
   struct vtable_incomplete;
   consteval {
     std::vector<std::meta::info> specs = {
@@ -206,6 +502,9 @@ class protocol : public reflection_detail::protocol_bases<T, Allocator> {
         std::meta::data_member_spec(^^destroy_fn,
                                     {
                                         .name = "xyz_protocol_destroy"}),
+        std::meta::data_member_spec(^^view_vtable_ptr,
+                                    {
+                                        .name = "view_vt"}),
     };
     for (std::meta::info spec :
          reflection_detail::define_vtable_entries(^^T, ^^void*, false)) {
@@ -262,6 +561,7 @@ class protocol : public reflection_detail::protocol_bases<T, Allocator> {
       vt.xyz_protocol_clone = xyz_protocol_clone;
       vt.xyz_protocol_move = xyz_protocol_move;
       vt.xyz_protocol_destroy = xyz_protocol_destroy;
+      vt.view_vt = &reflection_detail::view_vtable_for<T, Implementation>;
       template for (constexpr std::meta::info member : std::define_static_array(
                         reflection_detail::interface_member_functions(^^T))) {
         constexpr std::meta::info entry = reflection_detail::find_data_member(
@@ -486,6 +786,141 @@ class protocol : public reflection_detail::protocol_bases<T, Allocator> {
   }
 };
 
+template <typename T>
+class protocol_view<const T>
+    : public reflection_detail::protocol_const_view_bases<T> {
+  template <typename, std::meta::info, typename, typename...>
+  friend struct reflection_detail::protocol_const_view_single_overload_wrapper;
+  template <typename>
+  friend class protocol_view;
+
+  const void* ptr_;
+  const reflection_detail::const_view_vtable<T>* vptr_;
+
+  constexpr protocol_view(
+      const void* ptr,
+      const reflection_detail::const_view_vtable<T>* vptr) noexcept
+      : ptr_(ptr), vptr_(vptr) {}
+
+  template <typename Alloc>
+  static const void* checked_ptr(const protocol<T, Alloc>& p) noexcept {
+    assert(!p.valueless_after_move());
+    return p.p_;
+  }
+
+ public:
+  template <typename U>
+    requires reflection_detail::reflection_protocol_const_concept<U, T> &&
+                 not_protocol_or_view<U>
+  constexpr protocol_view(const U& obj) noexcept
+      : ptr_(std::addressof(obj)),
+        vptr_(
+            &reflection_detail::const_view_vtable_for<T,
+                                                      std::remove_cvref_t<U>>) {
+  }
+
+  template <typename U>
+    requires reflection_detail::reflection_protocol_const_concept<U, T> &&
+                 not_protocol_or_view<U>
+  protocol_view(const U&&) = delete;
+
+  template <typename Alloc>
+  protocol_view(const protocol<T, Alloc>& p) noexcept
+      : ptr_(checked_ptr(p)), vptr_(&p.vtable_->view_vt->const_view) {}
+
+  template <typename Alloc>
+  protocol_view(const protocol<T, Alloc>&&) = delete;
+
+  template <typename Alloc>
+  protocol_view(protocol<T, Alloc>& p) noexcept
+      : ptr_(checked_ptr(p)), vptr_(&p.vtable_->view_vt->const_view) {}
+
+  template <typename Alloc>
+  protocol_view(protocol<T, Alloc>&&) = delete;
+
+  constexpr protocol_view(protocol_view<T> other) noexcept;
+
+  template <typename Other>
+    requires(!std::same_as<Other, T>)
+  protocol_view(const protocol_view<const Other>& other) noexcept
+      : ptr_(other.ptr_), vptr_(get_const_vtable<Other, T>(other.vptr_)) {}
+
+  template <typename Other>
+    requires(!std::same_as<Other, T>)
+  protocol_view(const protocol_view<Other>& other) noexcept
+      : ptr_(other.ptr_),
+        vptr_(get_const_vtable<Other, T>(&other.vptr_->const_view)) {}
+
+  template <typename Other, typename Alloc>
+    requires(!std::same_as<Other, T>)
+  protocol_view(const protocol<Other, Alloc>& p) noexcept
+      : protocol_view(protocol_view<const Other>(p)) {}
+
+  template <typename Other, typename Alloc>
+    requires(!std::same_as<Other, T>)
+  protocol_view(const protocol<Other, Alloc>&&) = delete;
+
+  template <typename Other, typename Alloc>
+    requires(!std::same_as<Other, T>)
+  protocol_view(protocol<Other, Alloc>& p) noexcept
+      : protocol_view(protocol_view<Other>(p)) {}
+
+  template <typename Other, typename Alloc>
+    requires(!std::same_as<Other, T>)
+  protocol_view(protocol<Other, Alloc>&&) = delete;
+};
+
+template <typename T>
+class protocol_view : public reflection_detail::protocol_view_bases<T> {
+  template <typename, std::meta::info, typename, typename...>
+  friend struct reflection_detail::protocol_view_single_overload_wrapper;
+  template <typename>
+  friend class protocol_view;
+
+  void* ptr_;
+  const reflection_detail::view_vtable<T>* vptr_;
+
+  template <typename Alloc>
+  static void* checked_ptr(protocol<T, Alloc>& p) noexcept {
+    assert(!p.valueless_after_move());
+    return p.p_;
+  }
+
+ public:
+  template <typename U>
+    requires reflection_detail::reflection_protocol_concept<U, T> &&
+                 not_protocol_or_view<U>
+  constexpr protocol_view(U& obj) noexcept
+      : ptr_(std::addressof(obj)),
+        vptr_(&reflection_detail::view_vtable_for<T, std::remove_cvref_t<U>>) {}
+
+  template <typename U>
+    requires reflection_detail::reflection_protocol_concept<U, T> &&
+                 not_protocol_or_view<U>
+  protocol_view(const U&&) = delete;
+
+  template <typename Alloc>
+  protocol_view(protocol<T, Alloc>& p) noexcept
+      : ptr_(checked_ptr(p)), vptr_(p.vtable_->view_vt) {}
+
+  template <typename Alloc>
+  protocol_view(protocol<T, Alloc>&&) = delete;
+
+  template <typename Other>
+    requires(!std::same_as<Other, T>)
+  protocol_view(const protocol_view<Other>& other) noexcept
+      : ptr_(other.ptr_), vptr_(get_vtable<Other, T>(other.vptr_)) {}
+
+  template <typename Other, typename Alloc>
+    requires(!std::same_as<Other, T>)
+  protocol_view(protocol<Other, Alloc>& p) noexcept
+      : protocol_view(protocol_view<Other>(p)) {}
+
+  template <typename Other, typename Alloc>
+    requires(!std::same_as<Other, T>)
+  protocol_view(protocol<Other, Alloc>&&) = delete;
+};
+
 namespace reflection_detail {
 
 template <typename Interface, typename Allocator, std::meta::info Member,
@@ -511,7 +946,55 @@ R protocol_single_overload_wrapper<Interface, Allocator, Member, R,
   return owner->vtable_->[:entry:](owner->p_, std::forward<Ps>(ps)...);
 }
 
+template <typename Interface, std::meta::info Member, typename R,
+          typename... Ps>
+R protocol_view_single_overload_wrapper<Interface, Member, R,
+                                        Ps...>::operator()(Ps... ps) const
+    noexcept(std::meta::is_noexcept(Member)) {
+  using Owner = protocol_view<Interface>;
+  using Combined = protocol_view_member_wrapper<Interface, Member>;
+  constexpr std::meta::info representative =
+      members_named_like(^^Interface, Member)[0];
+  using Base = forwarder_base<Combined, representative>;
+  using ViewVtable = view_vtable<Interface>;
+  const auto* combined = static_cast<const Combined*>(this);
+  const auto* base =
+      static_cast<const Base*>(static_cast<const void*>(combined));
+  const auto* owner = static_cast<const Owner*>(base);
+  constexpr std::meta::info entry =
+      find_data_member(^^ViewVtable, vtable_slot_name(Member));
+  return owner->vptr_->[:entry:](owner->ptr_, std::forward<Ps>(ps)...);
+}
+
+template <typename Interface, std::meta::info Member, typename R,
+          typename... Ps>
+R protocol_const_view_single_overload_wrapper<Interface, Member, R,
+                                              Ps...>::operator()(Ps... ps) const
+    noexcept(std::meta::is_noexcept(Member)) {
+  using Owner = protocol_view<const Interface>;
+  using Combined = protocol_const_view_member_wrapper<Interface, Member>;
+  // Unlike the owning/mutable-view wrappers, the representative here must
+  // be the first *const* sibling: members_named_like(...)[0] could be a
+  // non-const overload the const view never exposes at all.
+  constexpr std::meta::info representative =
+      first_const_member_named_like(^^Interface, Member);
+  using Base = forwarder_base<Combined, representative>;
+  using ConstViewVtable = const_view_vtable<Interface>;
+  const auto* combined = static_cast<const Combined*>(this);
+  const auto* base =
+      static_cast<const Base*>(static_cast<const void*>(combined));
+  const auto* owner = static_cast<const Owner*>(base);
+  constexpr std::meta::info entry =
+      find_data_member(^^ConstViewVtable, vtable_slot_name(Member));
+  return owner->vptr_->[:entry:](owner->ptr_, std::forward<Ps>(ps)...);
+}
+
 }  // namespace reflection_detail
+
+template <typename T>
+inline constexpr protocol_view<const T>::protocol_view(
+    protocol_view<T> other) noexcept
+    : ptr_(other.ptr_), vptr_(&other.vptr_->const_view) {}
 
 }  // namespace xyz
 

--- a/protocol_reflection_smoke_test.cc
+++ b/protocol_reflection_smoke_test.cc
@@ -467,4 +467,179 @@ TEST(ProtocolReflectionSmoke, NarrowingConversionConcurrentStressing) {
   }
 }
 
+// xyz::protocol_view<T>/protocol_view<const T>: standalone equivalents of
+// protocol_test.cc's own ProtocolViewTest suite.
+
+TEST(ProtocolReflectionSmoke, ViewFromMutableConcrete) {
+  ALike a("view_test");
+  xyz::protocol_view<xyz::A> view(a);
+  EXPECT_EQ(view.name(), "view_test");
+  EXPECT_EQ(view.count(), 1);
+  EXPECT_EQ(a.count_, 1);  // The view mutated `a` directly.
+}
+
+TEST(ProtocolReflectionSmoke, ViewFromMutableProtocol) {
+  xyz::protocol<xyz::A> a(std::in_place_type<ALike>, "proto_view");
+  xyz::protocol_view<xyz::A> view(a);
+  EXPECT_EQ(view.name(), "proto_view");
+  EXPECT_EQ(view.count(), 1);
+  EXPECT_EQ(a.count(), 2);  // The view mutated `a` directly.
+}
+
+TEST(ProtocolReflectionSmoke, ConstViewFromMutableConcrete) {
+  ALike a("view_test");
+  xyz::protocol_view<const xyz::A> view(a);
+  EXPECT_EQ(view.name(), "view_test");
+}
+
+TEST(ProtocolReflectionSmoke, ConstViewFromMutableProtocol) {
+  xyz::protocol<xyz::A> a(std::in_place_type<ALike>, "proto_view");
+  xyz::protocol_view<const xyz::A> view(a);
+  EXPECT_EQ(view.name(), "proto_view");
+}
+
+TEST(ProtocolReflectionSmoke, ConstViewFromMutViewConcrete) {
+  ALike a("view_test");
+  xyz::protocol_view<xyz::A> mut_view(a);
+  xyz::protocol_view<const xyz::A> const_view(mut_view);
+  EXPECT_EQ(const_view.name(), "view_test");
+}
+
+TEST(ProtocolReflectionSmoke, ConstViewFromConstProtocol) {
+  const xyz::protocol<xyz::A> a(std::in_place_type<ALike>, "proto_view");
+  xyz::protocol_view<const xyz::A> view(a);
+  EXPECT_EQ(view.name(), "proto_view");
+}
+
+TEST(ProtocolReflectionSmoke, ViewConstnessRouting) {
+  BLike b;
+  xyz::protocol_view<xyz::B> view(b);
+  EXPECT_FALSE(view.is_ready());
+  view.process("view processing");
+  EXPECT_TRUE(view.is_ready());
+  auto results = view.get_results();
+  ASSERT_EQ(results.size(), 1u);
+  EXPECT_EQ(results[0], 15);
+}
+
+class CopyCounter {
+ public:
+  int* copies_;
+
+  explicit CopyCounter(int* copies) : copies_(copies) {}
+
+  CopyCounter(const CopyCounter& other) : copies_(other.copies_) {
+    if (copies_) (*copies_)++;
+  }
+
+  CopyCounter& operator=(const CopyCounter& other) {
+    copies_ = other.copies_;
+    if (copies_) (*copies_)++;
+    return *this;
+  }
+
+  CopyCounter(CopyCounter&&) = default;
+  CopyCounter& operator=(CopyCounter&&) = default;
+
+  std::string_view name() const noexcept { return "CopyCounter"; }
+
+  int count() { return 0; }
+};
+
+TEST(ProtocolReflectionSmoke, ViewCopiesAreShallow) {
+  int copies = 0;
+  CopyCounter c(&copies);
+  xyz::protocol_view<xyz::A> view(c);
+  EXPECT_EQ(copies, 0);
+
+  xyz::protocol_view<xyz::A> view2 = view;
+  EXPECT_EQ(copies, 0);
+
+  xyz::protocol_view<xyz::A> view3(view2);
+  EXPECT_EQ(view3.count(), 0);
+  EXPECT_EQ(copies, 0);
+}
+
+TEST(ProtocolReflectionSmoke, ViewMoveIsStandard) {
+  ALike a("move_test");
+  xyz::protocol_view<xyz::A> view(a);
+  xyz::protocol_view<xyz::A> view2 = std::move(view);
+
+  // Moved-from view is still valid: it's just a pointer copy.
+  EXPECT_EQ(view.name(), "move_test");
+  EXPECT_EQ(view2.name(), "move_test");
+}
+
+TEST(ProtocolReflectionSmoke, PreventConstructionFromRValues) {
+  static_assert(!std::constructible_from<xyz::protocol_view<xyz::A>, ALike>);
+  static_assert(!std::constructible_from<xyz::protocol_view<xyz::A>,
+                                         xyz::protocol<xyz::A>>);
+  static_assert(
+      !std::constructible_from<xyz::protocol_view<const xyz::A>, ALike>);
+  static_assert(!std::constructible_from<xyz::protocol_view<const xyz::A>,
+                                         xyz::protocol<xyz::A>>);
+  static_assert(!std::constructible_from<xyz::protocol_view<const xyz::A>,
+                                         const xyz::protocol<xyz::A>>);
+  static_assert(!std::constructible_from<xyz::protocol_view<xyz::A_Subset>,
+                                         xyz::protocol<xyz::A>>);
+  static_assert(
+      !std::constructible_from<xyz::protocol_view<const xyz::A_Subset>,
+                               xyz::protocol<xyz::A>>);
+}
+
+// Narrowing conversions between views: A -> A_Subset, mirroring the owning
+// narrowing tests above but through get_const_vtable/get_vtable instead of
+// get_owning_vtable.
+
+TEST(ProtocolReflectionSmoke, NarrowingViewConversions) {
+  ALike a_obj;
+  xyz::protocol_view<xyz::A> view_a(a_obj);
+
+  xyz::protocol_view<const xyz::A_Subset> const_view_subset = view_a;
+  EXPECT_EQ(const_view_subset.name(), "ALike");
+
+  xyz::protocol_view<xyz::A_Subset> view_subset = view_a;
+  EXPECT_EQ(view_subset.name(), "ALike");
+}
+
+TEST(ProtocolReflectionSmoke, ConstViewNarrowingFromConstView) {
+  ALike a_obj;
+  xyz::protocol_view<const xyz::A> const_a(a_obj);
+  xyz::protocol_view<const xyz::A_Subset> const_subset(const_a);
+  EXPECT_EQ(const_subset.name(), "ALike");
+}
+
+// The protocol_view counterpart to NarrowingConversionConcurrentStressing:
+// proves get_mapped_vtable caching/locking under contention for
+// protocol_view's own narrowing path too.
+TEST(ProtocolReflectionSmoke, ViewNarrowingConversionConcurrentStressing) {
+  constexpr int kNumThreads = 20;
+  constexpr int kIterationsPerThread = 50;
+  std::vector<std::thread> threads;
+  std::atomic<bool> start_signal{false};
+
+  for (int i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&start_signal]() {
+      while (!start_signal.load()) {
+        std::this_thread::yield();
+      }
+      for (int iter = 0; iter < kIterationsPerThread; ++iter) {
+        ALike a_obj;
+        xyz::protocol_view<xyz::A> view_a(a_obj);
+
+        xyz::protocol_view<const xyz::A_Subset> const_view = view_a;
+        EXPECT_EQ(const_view.name(), "ALike");
+
+        xyz::protocol_view<xyz::A_Subset> mut_view = view_a;
+        EXPECT_EQ(mut_view.name(), "ALike");
+      }
+    });
+  }
+
+  start_signal.store(true);
+  for (auto& thread : threads) {
+    thread.join();
+  }
+}
+
 }  // namespace


### PR DESCRIPTION
Non-owning views dispatching through a raw pointer/vtable pair
instead of protocol's allocator-owned storage, reusing the same
forwarder-combinator and thunk machinery; the const view exposes
only const members, through a const void*.

