### PR TITLE
Swap protocol_test.cc to the reflection backend; enable protocol_test_reflection (20/20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,8 +241,8 @@ if(XYZ_PROTOCOL_IS_NOT_SUBPROJECT)
       # a throwaway interface. XYZ_PROTOCOL_ENABLE_REFLECTION is the
       # source-level macro protocol.h checks to include protocol_reflection.hxx
       # instead of its placeholder primary templates; it is distinct from
-      # this XYZ_PROTOCOL_BUILD_REFLECTION_TUTORIAL CMake option, which only
-      # gates whether this target exists at all.
+      # this XYZ_PROTOCOL_USE_REFLECTION CMake option, which only gates
+      # whether this target exists at all.
       xyz_add_test(
         NAME
         protocol_reflection_smoke_test
@@ -266,6 +266,31 @@ if(XYZ_PROTOCOL_IS_NOT_SUBPROJECT)
       target_include_directories(protocol_reflection_smoke_test
                                  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
       set_target_properties(protocol_reflection_smoke_test PROPERTIES
+                            INTERPROCEDURAL_OPTIMIZATION OFF)
+
+      # protocol_test.cc itself, built against this backend instead of the
+      # Python/libclang-generated headers. D's operator tests are excluded
+      # (not supported yet).
+      xyz_add_test(
+        NAME
+        protocol_test_reflection
+        VERSION
+        26
+        LINK_LIBRARIES
+        protocol
+        FILES
+        protocol_test.cc
+        interface_A.h
+        interface_A_Subset.h
+        interface_B.h
+        interface_C.h
+        tracking_allocator.h)
+      target_compile_options(protocol_test_reflection PRIVATE -freflection)
+      target_compile_definitions(protocol_test_reflection
+                                 PRIVATE XYZ_PROTOCOL_ENABLE_REFLECTION)
+      target_include_directories(protocol_test_reflection
+                                 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+      set_target_properties(protocol_test_reflection PROPERTIES
                             INTERPROCEDURAL_OPTIMIZATION OFF)
     endif()
 

--- a/protocol_test.cc
+++ b/protocol_test.cc
@@ -29,11 +29,19 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <utility>
 #include <vector>
 
+#ifdef XYZ_PROTOCOL_ENABLE_REFLECTION
+// interface_D.h isn't needed: D's operator tests are excluded below.
+#include "interface_A.h"
+#include "interface_A_Subset.h"
+#include "interface_B.h"
+#include "interface_C.h"
+#else
 #include "generated/protocol_A.h"
 #include "generated/protocol_A_Subset.h"
 #include "generated/protocol_B.h"
 #include "generated/protocol_C.h"
 #include "generated/protocol_D.h"
+#endif  // XYZ_PROTOCOL_ENABLE_REFLECTION
 #include "tracking_allocator.h"
 
 namespace {
@@ -701,6 +709,11 @@ TEST(ProtocolViewTest, PreventConstructionFromRValues) {
       "compatible protocol");
 }
 
+// D's operators aren't supported by the reflection backend yet: naming.hxx
+// has no scheme for operators (they have no identifier_of), so reflecting
+// over D's members is a compile error, not just a failing dispatch call.
+#ifndef XYZ_PROTOCOL_ENABLE_REFLECTION
+
 class DLike {
   int value_ = 0;
 
@@ -916,6 +929,8 @@ TEST(ProtocolViewTest, ProtocolViewDOperators) {
   EXPECT_EQ(d(), 42);
   EXPECT_EQ(d[5], 10);
 }
+
+#endif  // XYZ_PROTOCOL_ENABLE_REFLECTION
 
 TEST(ProtocolViewTest, NarrowingConversion) {
   ALike a_obj;


### PR DESCRIPTION
Adds protocol_test_reflection, running protocol_test.cc against
protocol_reflection.hxx instead of the generated headers. Every test
passes except interface D's two operator tests, excluded until
operator support lands.

