### PR TITLE
Require exact return-type matches in generated protocol concepts

### DIFF
--- a/protocol_test.cc
+++ b/protocol_test.cc
@@ -506,41 +506,39 @@ TEST(ProtocolTest, SwapFromValueless) {
   EXPECT_TRUE(ppp.valueless_after_move());
 }
 
-class CovariantBImpl {
+// A B-shaped type whose methods return implicitly-convertible types instead
+// of B's exact declared return types.
+class AlmostBImpl {
   std::string last_input_;
 
  public:
-  // Testing discard: interface returns void, implementation returns int
   int process(const std::string& input) {
     last_input_ = input;
     return 42;
   }
 
-  // Testing implicit conversion: returns an implicitly convertible struct
-  // instead of std::vector
   struct VectorConvertible {
     operator std::vector<int>() const { return {1, 2, 3}; }
   };
 
   VectorConvertible get_results() const { return {}; }
 
-  // Testing implicit conversion: returns const char* instead of bool
   const char* is_ready() const { return "ready"; }
 
   std::string last_input() const { return last_input_; }
 };
 
-TEST(ProtocolTest, CovariantReturns) {
-  xyz::protocol<xyz::B> p(std::in_place_type<CovariantBImpl>);
-
-  p.process("hello covariant");
-  EXPECT_TRUE(p.is_ready());
-
-  std::vector<int> results = p.get_results();
-  ASSERT_EQ(results.size(), 3u);
-  EXPECT_EQ(results[0], 1);
-  EXPECT_EQ(results[1], 2);
-  EXPECT_EQ(results[2], 3);
+TEST(ProtocolTest, ConvertibleReturnsDoNotConform) {
+  // protocol requires exactly matching function signatures; it does not
+  // accept conformance through implicit conversion (the relaxed structural
+  // subtyping DRAFT.md considers and rejects as a design alternative).
+  // AlmostBImpl's methods are all individually callable but none returns
+  // B's exact declared type, so it does not conform.
+  static_assert(
+      !std::constructible_from<xyz::protocol<xyz::B>,
+                               std::in_place_type_t<AlmostBImpl>>,
+      "protocol<B> should not be constructible from a type whose methods "
+      "return convertible, not exact, types");
 }
 
 TEST(ProtocolViewTest, ViewFromMutableConcrete) {

--- a/reference_interface_protocol.h
+++ b/reference_interface_protocol.h
@@ -23,31 +23,31 @@ namespace xyz {
 
 template <typename T>
 concept protocol_const_concept_ReferenceInterface = requires(const T& t) {
-  { t.get_value() } -> std::convertible_to<int>;
+  { t.get_value() } -> std::same_as<int>;
 
-  { t.overloaded(std::declval<int>()) };
+  { t.overloaded(std::declval<int>()) } -> std::same_as<void>;
 
-  { t.overloaded(std::declval<std::string_view>()) };
+  { t.overloaded(std::declval<std::string_view>()) } -> std::same_as<void>;
 
   {
     t.operator()(std::declval<int>(), std::declval<int>())
-  } -> std::convertible_to<int>;
+  } -> std::same_as<int>;
 };
 
 template <typename T>
 concept protocol_concept_ReferenceInterface =
     protocol_const_concept_ReferenceInterface<T> && requires(T& t) {
-      { t.update(std::declval<const ReferencePoint&>(), std::declval<int*>()) };
-
       {
-        t.compute(std::declval<double>())
-      } noexcept -> std::convertible_to<double>;
+        t.update(std::declval<const ReferencePoint&>(), std::declval<int*>())
+      } -> std::same_as<void>;
 
-      { t.overloaded(std::declval<int>()) };
+      { t.compute(std::declval<double>()) } noexcept -> std::same_as<double>;
 
-      { t.operator+=(std::declval<int>()) };
+      { t.overloaded(std::declval<int>()) } -> std::same_as<void>;
 
-      { t.operator[](std::declval<std::size_t>()) } -> std::convertible_to<int>;
+      { t.operator+=(std::declval<int>()) } -> std::same_as<void>;
+
+      { t.operator[](std::declval<std::size_t>()) } -> std::same_as<int>;
     };
 
 struct const_view_vtable_ReferenceInterface {

--- a/scripts/protocol.j2
+++ b/scripts/protocol.j2
@@ -32,11 +32,7 @@ concept protocol_const_concept_{{ c.name }} = requires(const T& t) {
       {% set _ = declvals.append("std::declval<" ~ a.type.name ~ ">()") %}
     {% endfor %}
     {% set args_str = declvals | join(", ") %}
-    {% if m.return_type.name == 'void' %}
-  { t.{{ m.name }}({{ args_str }}) }{% if m.is_noexcept %} noexcept{% endif %};
-    {% else %}
-  { t.{{ m.name }}({{ args_str }}) }{% if m.is_noexcept %} noexcept{% endif %} -> std::convertible_to<{{ m.return_type.name }}>;
-    {% endif %}
+  { t.{{ m.name }}({{ args_str }}) }{% if m.is_noexcept %} noexcept{% endif %} -> std::same_as<{{ m.return_type.name }}>;
   {% endif %}
 {% endfor %}
 };
@@ -52,11 +48,7 @@ concept protocol_concept_{{ c.name }} = protocol_const_concept_{{ c.name }}<T>{%
     {% set _ = declvals.append("std::declval<" ~ a.type.name ~ ">()") %}
   {% endfor %}
   {% set args_str = declvals | join(", ") %}
-  {% if m.return_type.name == 'void' %}
-  { t.{{ m.name }}({{ args_str }}) }{% if m.is_noexcept %} noexcept{% endif %};
-  {% else %}
-  { t.{{ m.name }}({{ args_str }}) }{% if m.is_noexcept %} noexcept{% endif %} -> std::convertible_to<{{ m.return_type.name }}>;
-  {% endif %}
+  { t.{{ m.name }}({{ args_str }}) }{% if m.is_noexcept %} noexcept{% endif %} -> std::same_as<{{ m.return_type.name }}>;
 {% endfor %}
 }{% endif %};
 

--- a/scripts/test_concept_errors.py
+++ b/scripts/test_concept_errors.py
@@ -113,7 +113,7 @@ def test_wrong_return_type(compile_check: Callable[[str, List[str]], None]) -> N
     class BadALike_WrongReturnType {
     public:
         std::string_view name() const noexcept { return "name"; }
-        std::string count() { return "42"; }  // not convertible to int
+        std::string count() { return "42"; }  // not the same type as int
     };
 
     void test() {


### PR DESCRIPTION
protocol.j2's generated concepts used std::convertible_to<R>, letting
merely-convertible return types conform; switched to std::same_as<R>
per DRAFT.md's exact-match design. AlmostBImpl no longer conforms
to B and moves from a dispatch test to a negative static_assert.