### PR TITLE
Rename get_vtable/get_mutable_vtable to get_const_vtable/get_vtable

### DIFF
--- a/protocol.h
+++ b/protocol.h
@@ -58,7 +58,8 @@ const void* get_mapped_vtable(const void* source_vtable_pointer,
                                                        void* target));
 
 template <typename FromProtocol, typename ToProtocol>
-const typename protocol_vtable_traits<ToProtocol>::const_vtable* get_vtable(
+const typename protocol_vtable_traits<ToProtocol>::const_vtable*
+get_const_vtable(
     const typename protocol_vtable_traits<FromProtocol>::const_vtable*
         source_vtable_pointer) {
   using FromVtable =
@@ -68,8 +69,8 @@ const typename protocol_vtable_traits<ToProtocol>::const_vtable* get_vtable(
   static const char conversion_anchor = 0;
 
   auto mapping_function = [](const void* source, void* target) {
-    map_vtable_members(static_cast<const FromVtable*>(source),
-                       static_cast<ToVtable*>(target));
+    map_const_vtable_members(static_cast<const FromVtable*>(source),
+                             static_cast<ToVtable*>(target));
   };
 
   return static_cast<const ToVtable*>(
@@ -78,7 +79,7 @@ const typename protocol_vtable_traits<ToProtocol>::const_vtable* get_vtable(
 }
 
 template <typename FromProtocol, typename ToProtocol>
-const typename protocol_vtable_traits<ToProtocol>::vtable* get_mutable_vtable(
+const typename protocol_vtable_traits<ToProtocol>::vtable* get_vtable(
     const typename protocol_vtable_traits<FromProtocol>::vtable*
         source_vtable_pointer) {
   using FromVtable = typename protocol_vtable_traits<FromProtocol>::vtable;
@@ -87,8 +88,8 @@ const typename protocol_vtable_traits<ToProtocol>::vtable* get_mutable_vtable(
   static const char conversion_anchor = 0;
 
   auto mapping_function = [](const void* source, void* target) {
-    map_mutable_vtable_members(static_cast<const FromVtable*>(source),
-                               static_cast<ToVtable*>(target));
+    map_vtable_members(static_cast<const FromVtable*>(source),
+                       static_cast<ToVtable*>(target));
   };
 
   return static_cast<const ToVtable*>(

--- a/reference_interface_protocol.h
+++ b/reference_interface_protocol.h
@@ -141,8 +141,8 @@ struct protocol_owning_vtable_traits<::xyz::ReferenceInterface, Allocator> {
 };
 
 template <typename From>
-inline void map_vtable_members(const From* from,
-                               const_view_vtable_ReferenceInterface* to) {
+inline void map_const_vtable_members(const From* from,
+                                     const_view_vtable_ReferenceInterface* to) {
   to->get_value_51992268 = from->get_value_51992268;
 
   to->overloaded_c1840915 = from->overloaded_c1840915;
@@ -153,8 +153,8 @@ inline void map_vtable_members(const From* from,
 }
 
 template <typename From>
-inline void map_mutable_vtable_members(const From* from,
-                                       view_vtable_ReferenceInterface* to) {
+inline void map_vtable_members(const From* from,
+                               view_vtable_ReferenceInterface* to) {
   to->const_view.get_value_51992268 = from->const_view.get_value_51992268;
 
   to->const_view.overloaded_c1840915 = from->const_view.overloaded_c1840915;
@@ -184,8 +184,9 @@ inline void map_owning_vtable_members(
   to->xyz_protocol_clone = from->xyz_protocol_clone;
   to->xyz_protocol_move = from->xyz_protocol_move;
   to->xyz_protocol_destroy = from->xyz_protocol_destroy;
-  to->view_vt = get_mutable_vtable<typename From::protocol_type,
-                                   ::xyz::ReferenceInterface>(from->view_vt);
+  to->view_vt =
+      get_vtable<typename From::protocol_type, ::xyz::ReferenceInterface>(
+          from->view_vt);
 
   to->get_value_51992268 = from->get_value_51992268;
 
@@ -715,13 +716,14 @@ class protocol_view<const ::xyz::ReferenceInterface> {
     requires(!std::same_as<Other, ::xyz::ReferenceInterface>)
   protocol_view(const protocol_view<const Other>& other) noexcept
       : ptr_(other.ptr_),
-        vptr_(get_vtable<Other, ::xyz::ReferenceInterface>(other.vptr_)) {}
+        vptr_(get_const_vtable<Other, ::xyz::ReferenceInterface>(other.vptr_)) {
+  }
 
   template <typename Other>
     requires(!std::same_as<Other, ::xyz::ReferenceInterface>)
   protocol_view(const protocol_view<Other>& other) noexcept
       : ptr_(other.ptr_),
-        vptr_(get_vtable<Other, ::xyz::ReferenceInterface>(
+        vptr_(get_const_vtable<Other, ::xyz::ReferenceInterface>(
             &other.vptr_->const_view)) {}
 
   template <typename Other, typename Alloc>
@@ -795,9 +797,7 @@ class protocol_view<::xyz::ReferenceInterface> {
     requires(!std::same_as<Other, ::xyz::ReferenceInterface>)
   protocol_view(const protocol_view<Other>& other) noexcept
       : ptr_(other.ptr_),
-        vptr_(
-            get_mutable_vtable<Other, ::xyz::ReferenceInterface>(other.vptr_)) {
-  }
+        vptr_(get_vtable<Other, ::xyz::ReferenceInterface>(other.vptr_)) {}
 
   template <typename Other, typename Alloc>
     requires(!std::same_as<Other, ::xyz::ReferenceInterface>)

--- a/scripts/protocol.j2
+++ b/scripts/protocol.j2
@@ -136,14 +136,14 @@ struct protocol_owning_vtable_traits<{{ full_class_name }}, Allocator> {
 };
 
 template <typename From>
-inline void map_vtable_members(const From* from, const_view_vtable_{{ c.name }}* to) {
+inline void map_const_vtable_members(const From* from, const_view_vtable_{{ c.name }}* to) {
 {% for m in c.methods %}{% if m.is_const %}
   to->{{ m.name | mangle }}_{{ method_guids[loop.index0] }} = from->{{ m.name | mangle }}_{{ method_guids[loop.index0] }};
 {% endif %}{% endfor %}
 }
 
 template <typename From>
-inline void map_mutable_vtable_members(const From* from, view_vtable_{{ c.name }}* to) {
+inline void map_vtable_members(const From* from, view_vtable_{{ c.name }}* to) {
 {% for m in c.methods %}{% if m.is_const %}
   to->const_view.{{ m.name | mangle }}_{{ method_guids[loop.index0] }} = from->const_view.{{ m.name | mangle }}_{{ method_guids[loop.index0] }};
 {% endif %}{% endfor %}
@@ -157,7 +157,7 @@ inline void map_owning_vtable_members(const From* from, typename protocol_owning
   to->xyz_protocol_clone = from->xyz_protocol_clone;
   to->xyz_protocol_move = from->xyz_protocol_move;
   to->xyz_protocol_destroy = from->xyz_protocol_destroy;
-  to->view_vt = get_mutable_vtable<typename From::protocol_type, {{ full_class_name }}>(from->view_vt);
+  to->view_vt = get_vtable<typename From::protocol_type, {{ full_class_name }}>(from->view_vt);
 {% for m in c.methods %}
   to->{{ m.name | mangle }}_{{ method_guids[loop.index0] }} = from->{{ m.name | mangle }}_{{ method_guids[loop.index0] }};
 {% endfor %}
@@ -589,13 +589,13 @@ class protocol_view<const {{ full_class_name }}> {
     requires(!std::same_as<Other, {{ full_class_name }}>)
   protocol_view(const protocol_view<const Other>& other) noexcept
       : ptr_(other.ptr_),
-        vptr_(get_vtable<Other, {{ full_class_name }}>(other.vptr_)) {}
+        vptr_(get_const_vtable<Other, {{ full_class_name }}>(other.vptr_)) {}
 
   template <typename Other>
     requires(!std::same_as<Other, {{ full_class_name }}>)
   protocol_view(const protocol_view<Other>& other) noexcept
       : ptr_(other.ptr_),
-        vptr_(get_vtable<Other, {{ full_class_name }}>(&other.vptr_->const_view)) {}
+        vptr_(get_const_vtable<Other, {{ full_class_name }}>(&other.vptr_->const_view)) {}
 
   template <typename Other, typename Alloc>
     requires(!std::same_as<Other, {{ full_class_name }}>)
@@ -669,7 +669,7 @@ class protocol_view<{{ full_class_name }}> {
     requires(!std::same_as<Other, {{ full_class_name }}>)
   protocol_view(const protocol_view<Other>& other) noexcept
       : ptr_(other.ptr_),
-        vptr_(get_mutable_vtable<Other, {{ full_class_name }}>(other.vptr_)) {}
+        vptr_(get_vtable<Other, {{ full_class_name }}>(other.vptr_)) {}
 
   template <typename Other, typename Alloc>
     requires(!std::same_as<Other, {{ full_class_name }}>)


### PR DESCRIPTION
Matches protocol_vtable_traits::const_vtable/::vtable, which each
accessor narrows to. Pure rename, no behavior change.