### PR TITLE
Add a default allocator argument to the protocol primary template

### DIFF
--- a/protocol.h
+++ b/protocol.h
@@ -29,7 +29,7 @@ namespace xyz {
 template <typename T>
 struct is_protocol : std::false_type {};
 
-template <typename T, typename Alloc>
+template <typename T, typename Alloc = std::allocator<T>>
 class protocol;
 
 template <typename T, typename Alloc>
@@ -123,7 +123,7 @@ get_owning_vtable(const typename protocol_owning_vtable_traits<
                         sizeof(ToVtable), mapping_function));
 }
 
-template <typename T, typename A = std::allocator<T>>
+template <typename T, typename A>
 class protocol {
   static_assert(
       sizeof(T) == 0,

--- a/protocol.h
+++ b/protocol.h
@@ -29,11 +29,11 @@ namespace xyz {
 template <typename T>
 struct is_protocol : std::false_type {};
 
-template <typename T, typename Alloc = std::allocator<T>>
+template <typename T, typename Allocator = std::allocator<T>>
 class protocol;
 
-template <typename T, typename Alloc>
-struct is_protocol<protocol<T, Alloc>> : std::true_type {};
+template <typename T, typename Allocator>
+struct is_protocol<protocol<T, Allocator>> : std::true_type {};
 
 template <typename T>
 struct is_protocol_view : std::false_type {};
@@ -123,7 +123,7 @@ get_owning_vtable(const typename protocol_owning_vtable_traits<
                         sizeof(ToVtable), mapping_function));
 }
 
-template <typename T, typename A>
+template <typename T, typename Allocator>
 class protocol {
   static_assert(
       sizeof(T) == 0,


### PR DESCRIPTION
Moves the std::allocator<T> default from the definition to the
forward declaration, so protocol<T> is valid wherever only the
declaration is visible. A default can't be repeated on the same
parameter, so the definition drops its own.