### PR TITLE
Allocator tests

### DIFF
--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -589,7 +589,7 @@ TEST(ProtocolTest, MoveAssignmentUnequalPocma) {
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
 
-    // POCCA is true: p1 takes p2's allocator. Even though alloc1 != alloc2,
+    // POCMA is true: p1 takes p2's allocator. Even though alloc1 != alloc2,
     // p1 can just steal p2's pointer now, because it will have alloc2
     // henceforth.
     p1 = std::move(p2);

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -504,6 +504,7 @@ TEST(ProtocolTest, NarrowingMoveConstructionUnequal) {
   EXPECT_EQ(deallocs2, 1);
 }
 
+// Extends TrackingAllocator with POCCA set to true.
 template <typename T>
 struct PoccaAllocator : xyz::TrackingAllocator<T> {
   using xyz::TrackingAllocator<T>::TrackingAllocator;
@@ -531,13 +532,20 @@ TEST(ProtocolTest, CopyAssignmentUnequalPocca) {
     xyz::protocol<IntLike, PoccaAllocator<std::byte>> p2{std::allocator_arg,
                                                          alloc2, Tester{0}};
 
+    // p1 and p2 are both constructed with different allocators.
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
 
+    // POCCA is true: p1 should now take p2's allocator instead of keeping its
+    // own.
     p1 = p2;
+    EXPECT_EQ(p1.get_allocator(), alloc2);
 
-    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs1, 1);  // alloc1 only allocated once for p1.
+    // alloc2 allocated once for p2, and again when copying into p1.
     EXPECT_EQ(allocs2, 2);
+
+    // p1 was deallocated when it got assigned to.
     EXPECT_EQ(deallocs1, 1);
     EXPECT_EQ(deallocs2, 0);
   }
@@ -545,6 +553,7 @@ TEST(ProtocolTest, CopyAssignmentUnequalPocca) {
   EXPECT_EQ(deallocs1, 2);
 }
 
+// Extends TrackingAllocator with POCMA set to true.
 template <typename T>
 struct PocmaAllocator : xyz::TrackingAllocator<T> {
   using xyz::TrackingAllocator<T>::TrackingAllocator;
@@ -557,6 +566,10 @@ struct PocmaAllocator : xyz::TrackingAllocator<T> {
 };
 
 TEST(ProtocolTest, MoveAssignmentUnequalPocma) {
+  // Now that POCMA is true, move assignment should be noexcept.
+  static_assert(std::is_nothrow_move_assignable_v<
+                xyz::protocol<IntLike, PocmaAllocator<std::byte>>>);
+
   unsigned allocs1 = 0;
   unsigned deallocs1 = 0;
 
@@ -572,20 +585,27 @@ TEST(ProtocolTest, MoveAssignmentUnequalPocma) {
     xyz::protocol<IntLike, PocmaAllocator<std::byte>> p2{std::allocator_arg,
                                                          alloc2, Tester{10}};
 
+    // p1 and p2 are both constructed with different allocators.
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
 
+    // POCCA is true: p1 takes p2's allocator. Even though alloc1 != alloc2,
+    // p1 can just steal p2's pointer now, because it will have alloc2
+    // henceforth.
     p1 = std::move(p2);
-    EXPECT_EQ(allocs1, 1);
-    EXPECT_EQ(deallocs1, 1);
+    EXPECT_EQ(allocs1, 1);    // Still only the one original allocation.
+    EXPECT_EQ(deallocs1, 1);  // p1's original state was deallocated.
 
+    // No new allocations since it was just a pointer swap.
     EXPECT_EQ(allocs2, 1);
-    EXPECT_EQ(deallocs2, 0);
+    // The moved-from p2 has been deallocated.
+    EXPECT_EQ(deallocs2, 1);
   }
 
-  EXPECT_EQ(deallocs2, 1);
+  EXPECT_EQ(deallocs2, 2);
 }
 
+// Extends TrackingAllocator with POCS set to true.
 template <typename T>
 struct PocsAllocator : xyz::TrackingAllocator<T> {
   using xyz::TrackingAllocator<T>::TrackingAllocator;
@@ -598,6 +618,10 @@ struct PocsAllocator : xyz::TrackingAllocator<T> {
 };
 
 TEST(ProtocolTest, SwapUnequalPocs) {
+  // Even for unequal allocators, swapping should be noexcept when POCS is true.
+  static_assert(std::is_nothrow_swappable_v<
+                xyz::protocol<IntLike, PocsAllocator<std::byte>>>);
+
   unsigned allocs1 = 0;
   unsigned deallocs1 = 0;
 
@@ -612,15 +636,19 @@ TEST(ProtocolTest, SwapUnequalPocs) {
     xyz::protocol<IntLike, PocsAllocator<std::byte>> p2{std::allocator_arg,
                                                         alloc2, Tester{10}};
 
+    // p1 and p2 were constructed with different allocators.
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
 
+    // p1 and p2 now swap both their underlying types AND their allocators.
     using std::swap;
     swap(p1, p2);
 
+    // Allocators are now swapped.
     EXPECT_EQ(p1.get_allocator(), alloc2);
     EXPECT_EQ(p2.get_allocator(), alloc1);
 
+    // No new allocations were performed.
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
   }

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -1,11 +1,13 @@
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <vector>
+
 #include "protocol.h"
 #include "tagged_allocator.h"
 #include "tracking_allocator.h"
 
-#include <cstddef>
-#include <vector>
+namespace {
 
 struct Blank {};
 
@@ -24,22 +26,32 @@ struct NonCopyable {
 // implement small buffer optimization, and therefore we may find there are
 // fewer allocations than these tests suggest. To sidestep this, we can use
 // a type that is guaranteed to be larger than protocol.
+
+using TestAlloc = xyz::TrackingAllocator<std::byte>;
+using TestProtocol = xyz::protocol<Blank, TestAlloc>;
+
 struct Tester {
   int val;
-  Tester(int value) : val(value) {}
 
-  Tester(std::initializer_list<int>) {}
-private:
-  using P = xyz::protocol<Blank, xyz::TrackingAllocator<std::byte>>;
+  Tester(int value) noexcept : val(value) {}
+
+  Tester(std::initializer_list<int>) noexcept {}
+
+ private:
   std::array<std::byte, sizeof(P)> padding;
 };
 
 TEST(ProtocolTest, ConstructionAllocs) {
+  static_assert(
+      not std::is_nothrow_constructible_v<TestProtocol, std::allocator_arg_t,
+                                          TestAlloc, Tester>);
+
   unsigned allocs{};
   unsigned deallocs{};
   {
-    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
-    xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc, Tester{15}};
+    TestAlloc alloc{&allocs, &deallocs};
+    TestProtocol p{std::allocator_arg, alloc, Tester{15}};
+
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
   }
@@ -51,9 +63,9 @@ TEST(ProtocolTest, InPlaceConstructionAllocs) {
   unsigned allocs{};
   unsigned deallocs{};
   {
-    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
-    xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc,
-                                            std::in_place_type<Tester>, 15};
+    TestAlloc alloc{&allocs, &deallocs};
+    TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>, 15};
+
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
   }
@@ -65,9 +77,10 @@ TEST(ProtocolTest, InitListConstructionAllocs) {
   unsigned allocs{};
   unsigned deallocs{};
   {
-    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
-    xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc,
-                                            std::in_place_type<Tester>, {1, 2, 3}};
+    TestAlloc alloc{&allocs, &deallocs};
+    TestProtocol p{
+        std::allocator_arg, alloc, std::in_place_type<Tester>, {1, 2, 3}};
+
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
   }
@@ -76,11 +89,13 @@ TEST(ProtocolTest, InitListConstructionAllocs) {
 }
 
 TEST(ProtocolTest, CopyConstructionAllocs) {
+  static_assert(not std::is_nothrow_copy_constructible_v<TestProtocol>);
+
   unsigned allocs{};
   unsigned deallocs{};
   {
-    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
-    xyz::protocol<Blank, decltype(alloc)> p1{std::allocator_arg, alloc, Tester{25}};
+    TestAlloc alloc{&allocs, &deallocs};
+    TestProtocol p1{std::allocator_arg, alloc, Tester{25}};
     xyz::protocol p2{p1};
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
@@ -93,11 +108,11 @@ TEST(ProtocolTest, CopyConstructionEqualAllocs) {
   unsigned allocs{};
   unsigned deallocs{};
   {
-    xyz::TrackingAllocator<std::byte> alloc1{&allocs, &deallocs};
-    xyz::protocol<Blank, decltype(alloc1)> p1{std::allocator_arg, alloc, Tester{100}};
-    
-    xyz::TrackingAllocator<std::byte> alloc2{&allocs, &deallocs};
-    xyz::protocol<Blank, decltype(alloc2)> p2{std::allocator_arg, alloc2, p1};
+    TestAlloc alloc1{&allocs, &deallocs};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+
+    TestAlloc alloc2{&allocs, &deallocs};
+    TestProtocol p2{std::allocator_arg, alloc2, p1};
 
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
@@ -113,29 +128,29 @@ TEST(ProtocolTest, CopyConstructionUnequalAllocs) {
   unsigned allocs2{};
   unsigned deallocs2{};
   {
-    xyz::TrackingAllocator<std::byte> alloc1{&allocs1, &deallocs1};
-    xyz::protocol<Blank, decltype(alloc1)> p1{std::allocator_arg, alloc, Tester{100}};
-    
-    xyz::TrackingAllocator<std::byte> alloc2{&allocs2, &deallocs2};
-    xyz::protocol<Blank, decltype(alloc2)> p2{std::allocator_arg, alloc2, p1};
+    TestAlloc alloc1{&allocs1, &deallocs1};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+
+    TestAlloc alloc2{&allocs2, &deallocs2};
+    TestProtocol p2{std::allocator_arg, alloc2, p1};
 
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
     EXPECT_EQ(deallocs1, 0);
     EXPECT_EQ(deallocs2, 0);
   }
-  EXPECT_EQ(dealloc1, 1);
-  EXPECT_EQ(dealloc2, 1);
+  EXPECT_EQ(deallocs1, 1);
+  EXPECT_EQ(deallocs2, 1);
 }
 
-TEST(ProtocolTest, CopyAssignmentAllocs) {
+TEST(ProtocolTest, CopyAssignmentEqualAllocs) {
   unsigned allocs{};
   unsigned deallocs{};
   {
-    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
-    
-    xyz::protocol<Blank, decltype(alloc)> p1{std::allocator_arg, alloc, Tester{30}};
-    xyz::protocol<Blank, decltype(alloc)> p2{Tester{40}};
+    TestAlloc alloc{&allocs, &deallocs};
+
+    TestProtocol p1{std::allocator_arg, alloc, Tester{30}};
+    TestProtocol p2{Tester{40}};
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
 
@@ -147,17 +162,131 @@ TEST(ProtocolTest, CopyAssignmentAllocs) {
   EXPECT_EQ(deallocs, 3);
 }
 
-Test(ProtocolTest, MoveConstructionAllocs) {
+TEST(ProtocolTest, CopyAssignmentUnequalAllocs) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+  {
+    TestAlloc alloc1{&allocs1, &deallocs1};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+
+    TestAlloc alloc2{&allocs2, &deallocs2};
+    TestProtocol p2{std::allocator_arg, alloc2, p1};
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+
+    p1 = p2;
+
+    EXPECT_EQ(allocs1, 2);
+    EXPECT_EQ(allocs2, 1);
+  }
+  EXPECT_EQ(deallocs1, 2);
+  EXPECT_EQ(deallocs2, 1);
+}
+
+TEST(ProtocolTest, MoveConstructionAllocs) {
+  static_assert(std::is_nothrow_move_constructible_v<TestProtocol>);
+
   unsigned allocs{};
   unsigned deallocs{};
   {
-    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
-    
-    xyz::protocol<Blank, decltype(alloc)> p1{std::allocator_arg, alloc, Tester{50}};
+    TestAlloc alloc{&allocs, &deallocs};
+
+    TestProtocol p1{std::allocator_arg, alloc, Tester{50}};
     xyz::protocol p2{std::move(p1)};
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
   }
   EXPECT_EQ(allocs, 1);
   EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, MoveConstructionEqualAllocs) {
+  static_assert(not std::is_nothrow_constructible_v<TestProtocol, std::allocator_arg_t, TestAlloc, TestProtocol&&>);
+
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    TestAlloc alloc1{&allocs, &deallocs};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+
+    TestAlloc alloc2{&allocs, &deallocs};
+    TestProtocol p2{std::allocator_arg, alloc2, std::move(p1)};
+
+    EXPECT_EQ(allocs, 1);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(allocs, 1);
+  EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, MoveConstructionUnequalAllocs) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+  {
+    TestAlloc alloc1{&allocs1, &deallocs1};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+
+    TestAlloc alloc2{&allocs2, &deallocs2};
+    TestProtocol p2{std::allocator_arg, alloc2, std::move(p1)};
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+    EXPECT_EQ(deallocs1, 0);
+    EXPECT_EQ(deallocs2, 0);
+  }
+  EXPECT_EQ(deallocs1, 1);
+  EXPECT_EQ(deallocs2, 1);
+}
+
+TEST(ProtocolTest, MoveAssignmentEqualAllocs) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    TestAlloc alloc{&allocs, &deallocs};
+
+    TestProtocol p1{std::allocator_arg, alloc, Tester{30}};
+    TestProtocol p2{Tester{40}};
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(deallocs, 0);
+
+    p1 = std::move(p2);
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(deallocs, 1);
+  }
+  EXPECT_EQ(allocs, 2);
+  EXPECT_EQ(deallocs, 2);
+}
+
+TEST(ProtocolTest, MoveAssignmentUnequalAllocs) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+  {
+    TestAlloc alloc1{&allocs1, &deallocs1};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+
+    TestAlloc alloc2{&allocs2, &deallocs2};
+    TestProtocol p2{std::allocator_arg, alloc2, p1};
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+
+    p1 = std::move(p2);
+
+    EXPECT_EQ(allocs1, 2);
+    EXPECT_EQ(allocs2, 1);
+  }
+  EXPECT_EQ(deallocs1, 2);
+  EXPECT_EQ(deallocs2, 1);
+}
+
 }

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -4,6 +4,9 @@
 #include "tagged_allocator.h"
 #include "tracking_allocator.h"
 
+#include <cstddef>
+#include <vector>
+
 struct Blank {};
 
 struct NonCopyable {
@@ -16,12 +19,27 @@ struct NonCopyable {
   ~NonCopyable() = default;
 };
 
+// IMPORTANT: Allocation counting assumes that protocol is always deferring
+// to its allocator when creating a value. In reality, it should probably
+// implement small buffer optimization, and therefore we may find there are
+// fewer allocations than these tests suggest. To sidestep this, we can use
+// a type that is guaranteed to be larger than protocol.
+struct Tester {
+  int val;
+  Tester(int value) : val(value) {}
+
+  Tester(std::initializer_list<int>) {}
+private:
+  using P = xyz::protocol<Blank, xyz::TrackingAllocator<std::byte>>;
+  std::array<std::byte, sizeof(P)> padding;
+};
+
 TEST(ProtocolTest, ConstructionAllocs) {
   unsigned allocs{};
   unsigned deallocs{};
   {
     xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
-    xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc, 15};
+    xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc, Tester{15}};
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
   }
@@ -35,10 +53,57 @@ TEST(ProtocolTest, InPlaceConstructionAllocs) {
   {
     xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
     xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc,
-                                            std::in_place_type<int>, 15};
+                                            std::in_place_type<Tester>, 15};
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
   }
   EXPECT_EQ(allocs, 1);
   EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, InitListConstructionAllocs) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
+    xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc,
+                                            std::in_place_type<Tester>, {1, 2, 3}};
+    EXPECT_EQ(allocs, 1);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(allocs, 1);
+  EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, CopyConstructionAllocs) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
+    xyz::protocol<Blank, decltype(alloc)> p1{std::allocator_arg, alloc, Tester{25}};
+    xyz::protocol p2{p1};
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(allocs, 2);
+  EXPECT_EQ(deallocs, 2);
+}
+
+TEST(ProtocolTest, CopyAssignmentAllocs) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
+    
+    xyz::protocol<Blank, decltype(alloc)> p1{std::allocator_arg, alloc, Tester{30}};
+    xyz::protocol p2{std::allocator_arg, alloc, Tester{40}};
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(deallocs, 0);
+
+    p1 = p2;
+    EXPECT_EQ(allocs, 3);
+    EXPECT_EQ(deallocs, 1);
+  }
+  EXPECT_EQ(allocs, 2);
+  EXPECT_EQ(deallocs, 2);
 }

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -15,6 +15,8 @@ struct IntLike {
   int value() const noexcept;
 };
 
+struct Blank {};
+
 using TestAlloc = xyz::TrackingAllocator<std::byte>;
 using TestProtocol = xyz::protocol<IntLike, TestAlloc>;
 
@@ -305,6 +307,87 @@ TEST(ProtocolTest, SwapEqual) {
     EXPECT_EQ(p2.get_allocator(), alloc2);
   }
   EXPECT_EQ(deallocs, 2);
+}
+
+TEST(ProtocolTest, NarrowingCopyConstruction) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    TestAlloc alloc1{&allocs, &deallocs};
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{p1};
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(deallocs, 2);
+}
+
+TEST(ProtocolTest, NarrowingCopyConstructionUnequal) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+
+  {
+    TestAlloc alloc1{&allocs1, &deallocs1};
+    TestAlloc alloc2{&allocs2, &deallocs2};
+
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, p1};
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+  }
+  EXPECT_EQ(deallocs1, 1);
+  EXPECT_EQ(deallocs2, 1);
+}
+
+TEST(ProtocolTest, NarrowingMoveConstruction) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    TestAlloc alloc1{&allocs, &deallocs};
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::move(p1)};
+    EXPECT_EQ(allocs, 1);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, NarrowingMoveConstructionEqual) {
+  unsigned allocs{};
+  unsigned deallocs{};
+
+  {
+    TestAlloc alloc1{&allocs, &deallocs};
+    TestAlloc alloc2{&allocs, &deallocs};
+
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, std::move(p1)};
+    EXPECT_EQ(allocs, 1);
+  }
+  EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, NarrowingMoveConstructionUnequal) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+
+  {
+    TestAlloc alloc1{&allocs1, &deallocs1};
+    TestAlloc alloc2{&allocs2, &deallocs2};
+
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, std::move(p1)};
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+  }
+  EXPECT_EQ(deallocs1, 1);
+  EXPECT_EQ(deallocs2, 1);
 }
 
 // Tests that swap fails gracefully with an assert in debug mode.

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -1,3 +1,23 @@
+/* Copyright (c) 2016 The Value Types Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+
 #include <gtest/gtest.h>
 
 #include <array>

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -62,8 +62,8 @@ TEST(ProtocolTest, Construction) {
       not std::is_nothrow_constructible_v<TestProtocol, std::allocator_arg_t,
                                           TestAlloc, Tester>);
 
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
     TestProtocol p{std::allocator_arg, alloc, Tester{15}};
@@ -76,8 +76,8 @@ TEST(ProtocolTest, Construction) {
 }
 
 TEST(ProtocolTest, InPlaceConstruction) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
     TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>, 15};
@@ -90,8 +90,8 @@ TEST(ProtocolTest, InPlaceConstruction) {
 }
 
 TEST(ProtocolTest, InitListConstruction) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
     TestProtocol p{
@@ -107,8 +107,8 @@ TEST(ProtocolTest, InitListConstruction) {
 TEST(ProtocolTest, CopyConstruction) {
   static_assert(not std::is_nothrow_copy_constructible_v<TestProtocol>);
 
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
     TestProtocol p1{std::allocator_arg, alloc, Tester{25}};
@@ -121,8 +121,8 @@ TEST(ProtocolTest, CopyConstruction) {
 }
 
 TEST(ProtocolTest, CopyConstructionEqual) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc1{&allocs, &deallocs};
     TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
@@ -138,11 +138,11 @@ TEST(ProtocolTest, CopyConstructionEqual) {
 }
 
 TEST(ProtocolTest, CopyConstructionUnequal) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
     TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
@@ -160,8 +160,8 @@ TEST(ProtocolTest, CopyConstructionUnequal) {
 }
 
 TEST(ProtocolTest, CopyAssignmentEqual) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
 
@@ -179,11 +179,11 @@ TEST(ProtocolTest, CopyAssignmentEqual) {
 }
 
 TEST(ProtocolTest, CopyAssignmentUnequal) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
     TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
@@ -206,8 +206,8 @@ TEST(ProtocolTest, CopyAssignmentUnequal) {
 TEST(ProtocolTest, MoveConstruction) {
   static_assert(std::is_nothrow_move_constructible_v<TestProtocol>);
 
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
 
@@ -225,8 +225,8 @@ TEST(ProtocolTest, MoveConstructionEqual) {
       not std::is_nothrow_constructible_v<TestProtocol, std::allocator_arg_t,
                                           TestAlloc, TestProtocol&&>);
 
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc1{&allocs, &deallocs};
     TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
@@ -242,11 +242,11 @@ TEST(ProtocolTest, MoveConstructionEqual) {
 }
 
 TEST(ProtocolTest, MoveConstructionUnequal) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
     TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
@@ -263,8 +263,8 @@ TEST(ProtocolTest, MoveConstructionUnequal) {
 }
 
 TEST(ProtocolTest, MoveAssignmentEqual) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
 
@@ -282,11 +282,11 @@ TEST(ProtocolTest, MoveAssignmentEqual) {
 }
 
 TEST(ProtocolTest, MoveAssignmentUnequal) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
     TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
@@ -307,8 +307,8 @@ TEST(ProtocolTest, MoveAssignmentUnequal) {
 }
 
 TEST(ProtocolTest, SwapEqual) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc1{&allocs, &deallocs};
     TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
@@ -330,8 +330,8 @@ TEST(ProtocolTest, SwapEqual) {
 }
 
 TEST(ProtocolTest, NarrowingCopyConstruction) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc1{&allocs, &deallocs};
     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
@@ -344,11 +344,11 @@ TEST(ProtocolTest, NarrowingCopyConstruction) {
 }
 
 TEST(ProtocolTest, NarrowingCopyConstructionUnequal) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
 
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
@@ -365,8 +365,8 @@ TEST(ProtocolTest, NarrowingCopyConstructionUnequal) {
 }
 
 TEST(ProtocolTest, NarrowingMoveConstruction) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   {
     TestAlloc alloc1{&allocs, &deallocs};
     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
@@ -379,8 +379,8 @@ TEST(ProtocolTest, NarrowingMoveConstruction) {
 }
 
 TEST(ProtocolTest, NarrowingMoveConstructionEqual) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
 
   {
     TestAlloc alloc1{&allocs, &deallocs};
@@ -396,11 +396,11 @@ TEST(ProtocolTest, NarrowingMoveConstructionEqual) {
 }
 
 TEST(ProtocolTest, NarrowingMoveConstructionUnequal) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
 
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
@@ -421,13 +421,13 @@ TEST(ProtocolTest, NarrowingMoveConstructionUnequal) {
 // In release mode, this is undefined behavior.
 #if (defined(_MSC_VER) && defined(_DEBUG)) || (!defined(NDEBUG))
 TEST(ProtocolTest, SwapUnequal) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
   TestAlloc alloc1{&allocs1, &deallocs1};
   TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
   TestAlloc alloc2{&allocs2, &deallocs2};
   TestProtocol p2{std::allocator_arg, alloc2, p1};
 
@@ -449,11 +449,11 @@ struct PoccaAllocator : xyz::TrackingAllocator<T> {
 };
 
 TEST(ProtocolTest, CopyAssignmentUnequalPocca) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
 
   {
     PoccaAllocator<std::byte> alloc1{&allocs1, &deallocs1};
@@ -490,11 +490,11 @@ struct PocmaAllocator : xyz::TrackingAllocator<T> {
 };
 
 TEST(ProtocolTest, MoveAssignmentUnequalPocma) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
 
   {
     PocmaAllocator<std::byte> alloc1{&allocs1, &deallocs1};
@@ -531,11 +531,11 @@ struct PocsAllocator : xyz::TrackingAllocator<T> {
 };
 
 TEST(ProtocolTest, SwapUnequalPocs) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
   {
     PocsAllocator<std::byte> alloc1{&allocs1, &deallocs1};
     xyz::protocol<IntLike, PocsAllocator<std::byte>> p1{std::allocator_arg,
@@ -590,8 +590,8 @@ using ThrowingAlloc = ThrowingAllocator<std::byte>;
 using ThrowingProtocol = xyz::protocol<IntLike, ThrowingAlloc>;
 
 TEST(ProtocolTest, ConstructionException) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
   bool should_throw{true};
 
   ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
@@ -602,8 +602,8 @@ TEST(ProtocolTest, ConstructionException) {
 }
 
 TEST(ProtocolTest, CopyConstructionException) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
 
   {
     bool should_throw{false};
@@ -621,8 +621,8 @@ TEST(ProtocolTest, CopyConstructionException) {
 }
 
 TEST(ProtocolTest, CopyAssignmentException) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
 
   {
     bool should_throw{false};
@@ -644,8 +644,8 @@ TEST(ProtocolTest, CopyAssignmentException) {
 }
 
 TEST(ProtocolTest, EqualMoveConstructionNoException) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
 
   {
     bool should_throw{false};
@@ -663,11 +663,11 @@ TEST(ProtocolTest, EqualMoveConstructionNoException) {
 }
 
 TEST(ProtocolTest, UnequalMoveConstructionException) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
 
   {
     bool should_throw{false};
@@ -691,8 +691,8 @@ TEST(ProtocolTest, UnequalMoveConstructionException) {
 }
 
 TEST(ProtocolTest, EqualMoveAssignmentNoException) {
-  unsigned allocs{};
-  unsigned deallocs{};
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
 
   {
     bool should_throw{false};
@@ -712,11 +712,11 @@ TEST(ProtocolTest, EqualMoveAssignmentNoException) {
 }
 
 TEST(ProtocolTest, UnequalMoveAssignmentException) {
-  unsigned allocs1{};
-  unsigned deallocs1{};
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
 
-  unsigned allocs2{};
-  unsigned deallocs2{};
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
 
   {
     bool should_throw1{false};

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -89,6 +89,45 @@ TEST(ProtocolTest, CopyConstructionAllocs) {
   EXPECT_EQ(deallocs, 2);
 }
 
+TEST(ProtocolTest, CopyConstructionEqualAllocs) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    xyz::TrackingAllocator<std::byte> alloc1{&allocs, &deallocs};
+    xyz::protocol<Blank, decltype(alloc1)> p1{std::allocator_arg, alloc, Tester{100}};
+    
+    xyz::TrackingAllocator<std::byte> alloc2{&allocs, &deallocs};
+    xyz::protocol<Blank, decltype(alloc2)> p2{std::allocator_arg, alloc2, p1};
+
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(allocs, 2);
+  EXPECT_EQ(deallocs, 2);
+}
+
+TEST(ProtocolTest, CopyConstructionUnequalAllocs) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+  {
+    xyz::TrackingAllocator<std::byte> alloc1{&allocs1, &deallocs1};
+    xyz::protocol<Blank, decltype(alloc1)> p1{std::allocator_arg, alloc, Tester{100}};
+    
+    xyz::TrackingAllocator<std::byte> alloc2{&allocs2, &deallocs2};
+    xyz::protocol<Blank, decltype(alloc2)> p2{std::allocator_arg, alloc2, p1};
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+    EXPECT_EQ(deallocs1, 0);
+    EXPECT_EQ(deallocs2, 0);
+  }
+  EXPECT_EQ(dealloc1, 1);
+  EXPECT_EQ(dealloc2, 1);
+}
+
 TEST(ProtocolTest, CopyAssignmentAllocs) {
   unsigned allocs{};
   unsigned deallocs{};
@@ -96,7 +135,7 @@ TEST(ProtocolTest, CopyAssignmentAllocs) {
     xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
     
     xyz::protocol<Blank, decltype(alloc)> p1{std::allocator_arg, alloc, Tester{30}};
-    xyz::protocol p2{std::allocator_arg, alloc, Tester{40}};
+    xyz::protocol<Blank, decltype(alloc)> p2{Tester{40}};
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
 
@@ -104,6 +143,21 @@ TEST(ProtocolTest, CopyAssignmentAllocs) {
     EXPECT_EQ(allocs, 3);
     EXPECT_EQ(deallocs, 1);
   }
-  EXPECT_EQ(allocs, 2);
-  EXPECT_EQ(deallocs, 2);
+  EXPECT_EQ(allocs, 3);
+  EXPECT_EQ(deallocs, 3);
+}
+
+Test(ProtocolTest, MoveConstructionAllocs) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
+    
+    xyz::protocol<Blank, decltype(alloc)> p1{std::allocator_arg, alloc, Tester{50}};
+    xyz::protocol p2{std::move(p1)};
+    EXPECT_EQ(allocs, 1);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(allocs, 1);
+  EXPECT_EQ(deallocs, 1);
 }

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstddef>
-#include <vector>
+#include <new>
+#include <type_traits>
 
 #include "protocol.h"
 #include "tagged_allocator.h"
@@ -142,7 +144,7 @@ TEST(ProtocolTest, CopyAssignmentEqual) {
     TestAlloc alloc{&allocs, &deallocs};
 
     TestProtocol p1{std::allocator_arg, alloc, Tester{30}};
-    TestProtocol p2{Tester{40}};
+    TestProtocol p2{std::allocator_arg, alloc, Tester{40}};
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
 
@@ -320,7 +322,7 @@ TEST(ProtocolTest, SwapUnequal) {
   TestProtocol p2{std::allocator_arg, alloc2, p1};
 
   using std::swap;
-  EXPECT_DEATH(swap(p1, p2));
+  EXPECT_DEATH(swap(p1, p2), "allocators must compare equal or propagate on swap");
 }
 #endif
 
@@ -332,7 +334,7 @@ struct PoccaAllocator : xyz::TrackingAllocator<T> {
   template <typename Other>
   struct rebind {
     using other = PoccaAllocator<Other>;
-  }
+  };
 };
 
 TEST(ProtocolTest, CopyAssignmentUnequalPocca) {
@@ -355,9 +357,11 @@ TEST(ProtocolTest, CopyAssignmentUnequalPocca) {
     EXPECT_EQ(allocs2, 1);
 
     p1 = p2;
-    EXPECT_EQ(allocs1, 2);
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 2);
     EXPECT_EQ(deallocs1, 1);
-    EXPECT_EQ(deallocs2, 1);
+    EXPECT_EQ(deallocs2, 0);
   }
 
   EXPECT_EQ(deallocs1, 2);
@@ -371,7 +375,7 @@ struct PocmaAllocator : xyz::TrackingAllocator<T> {
   template <typename Other>
   struct rebind {
     using other = PocmaAllocator<Other>;
-  }
+  };
 };
 
 TEST(ProtocolTest, MoveAssignmentUnequalPocma) {
@@ -412,7 +416,7 @@ struct PocsAllocator : xyz::TrackingAllocator<T> {
   template <typename Other>
   struct rebind {
     using other = PocsAllocator<Other>;
-  }
+  };
 };
 
 TEST(ProtocolTest, SwapUnequalPocs) {
@@ -434,7 +438,7 @@ TEST(ProtocolTest, SwapUnequalPocs) {
     EXPECT_EQ(allocs2, 1);
 
     using std::swap;
-    swap(alloc1, alloc2);
+    swap(p1, p2);
 
     EXPECT_EQ(p1.get_allocator(), alloc2);
     EXPECT_EQ(p2.get_allocator(), alloc1);
@@ -447,17 +451,15 @@ TEST(ProtocolTest, SwapUnequalPocs) {
   EXPECT_EQ(deallocs2, 1);
 }
 
-struct TestException : std::bad_alloc {
-  const char* what() const noexcept override { return bad_alloc::what(); }
-};
+struct TestException : std::bad_alloc {};
 
 template <typename T>
 struct ThrowingAllocator : xyz::TrackingAllocator<T> {
   const bool* should_throw_;
 
-  template <typename U>
+  template <typename Other>
   struct rebind {
-    using other = ThrowingAllocator<T>;
+    using other = ThrowingAllocator<Other>;
   };
 
   ThrowingAllocator(unsigned* allocs, unsigned* deallocs,
@@ -466,15 +468,15 @@ struct ThrowingAllocator : xyz::TrackingAllocator<T> {
 
   T* allocate(std::size_t count) {
     if (should_throw_) {
-      throw std::bad_alloc{};
+      throw TestException{};
     }
-    TrackingAllocator::allocate();
+    return TrackingAllocator<T>::allocate(count);
   }
 };
 
 using ThrowingAlloc = ThrowingAllocator<std::byte>;
 
-using ThrowingProtocol = xyz::protocol<IntLike, ThrowingAlloc>
+using ThrowingProtocol = xyz::protocol<IntLike, ThrowingAlloc>;
 
 TEST(ProtocolTest, ConstructionException) {
   unsigned allocs{};
@@ -519,13 +521,13 @@ TEST(ProtocolTest, CopyAssignmentException) {
     ThrowingProtocol p2{std::allocator_arg, alloc, Tester{20}};
 
     EXPECT_EQ(allocs, 2);
-    EXPECT_EQ(allocs, 0);
+    EXPECT_EQ(deallocs, 0);
 
     should_throw = true;
     EXPECT_THROW(p2 = p1, TestException);
 
     EXPECT_EQ(p1.value(), 10);
-    EXPECT_EQ(p2.value(), 10);
+    EXPECT_EQ(p2.value(), 20);
   }
   EXPECT_EQ(deallocs, 2);
 }
@@ -564,7 +566,7 @@ TEST(ProtocolTest, UnequalMoveConstructionException) {
    
     should_throw = true;
     ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw};
-    EXPECT_THROW(ThrowingProtocol{std::allocator_arg, alloc, std::move(p1)}, TestException);
+    EXPECT_THROW(ThrowingProtocol{std::allocator_arg, alloc2, std::move(p1)}, TestException);
 
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(deallocs1, 0);

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -1,30 +1,44 @@
+#include <gtest/gtest.h>
+
 #include "protocol.h"
 #include "tagged_allocator.h"
 #include "tracking_allocator.h"
 
-#include <gtest/gtest.h>
-
 struct Blank {};
+
 struct NonCopyable {
-    NonCopyable(const NonCopyable&) = delete;
-    NonCopyable& operator=(const NonCopyable&) = delete;
+  NonCopyable(const NonCopyable&) = delete;
+  NonCopyable& operator=(const NonCopyable&) = delete;
 
-    NonCopyable(NonCopyable&&) = default;
-    NonCopyable& operator=(NonCopyable&&) = default;
+  NonCopyable(NonCopyable&&) = default;
+  NonCopyable& operator=(NonCopyable&&) = default;
 
-    ~NonCopyable() = default;
+  ~NonCopyable() = default;
 };
 
-TEST(ProtocolTest, ConstructionAllocations) {
-    unsigned allocs{};
-    unsigned deallocs{};
-    {
-        xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
-        xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc, 15};
-        EXPECT_EQ(allocs, 1);
-        EXPECT_EQ(deallocs, 0);
-    }
+TEST(ProtocolTest, ConstructionAllocs) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
+    xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc, 15};
     EXPECT_EQ(allocs, 1);
-    EXPECT_EQ(deallocs, 1);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(allocs, 1);
+  EXPECT_EQ(deallocs, 1);
 }
 
+TEST(ProtocolTest, InPlaceConstructionAllocs) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
+    xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc,
+                                            std::in_place_type<int>, 15};
+    EXPECT_EQ(allocs, 1);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(allocs, 1);
+  EXPECT_EQ(deallocs, 1);
+}

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -21,12 +21,6 @@ struct NonCopyable {
   ~NonCopyable() = default;
 };
 
-// IMPORTANT: Allocation counting assumes that protocol is always deferring
-// to its allocator when creating a value. In reality, it should probably
-// implement small buffer optimization, and therefore we may find there are
-// fewer allocations than these tests suggest. To sidestep this, we can use
-// a type that is guaranteed to be larger than protocol.
-
 using TestAlloc = xyz::TrackingAllocator<std::byte>;
 using TestProtocol = xyz::protocol<Blank, TestAlloc>;
 
@@ -38,10 +32,14 @@ struct Tester {
   Tester(std::initializer_list<int>) noexcept {}
 
  private:
+  // protocol should probably
+  // implement small buffer optimization, and therefore we may find there are
+  // fewer allocations than these tests suggest. To sidestep this, we can use
+  // a type that is guaranteed to be larger than protocol.
   std::array<std::byte, sizeof(P)> padding;
 };
 
-TEST(ProtocolTest, ConstructionAllocs) {
+TEST(ProtocolTest, Construction) {
   static_assert(
       not std::is_nothrow_constructible_v<TestProtocol, std::allocator_arg_t,
                                           TestAlloc, Tester>);
@@ -59,7 +57,7 @@ TEST(ProtocolTest, ConstructionAllocs) {
   EXPECT_EQ(deallocs, 1);
 }
 
-TEST(ProtocolTest, InPlaceConstructionAllocs) {
+TEST(ProtocolTest, InPlaceConstruction) {
   unsigned allocs{};
   unsigned deallocs{};
   {
@@ -73,7 +71,7 @@ TEST(ProtocolTest, InPlaceConstructionAllocs) {
   EXPECT_EQ(deallocs, 1);
 }
 
-TEST(ProtocolTest, InitListConstructionAllocs) {
+TEST(ProtocolTest, InitListConstruction) {
   unsigned allocs{};
   unsigned deallocs{};
   {
@@ -88,7 +86,7 @@ TEST(ProtocolTest, InitListConstructionAllocs) {
   EXPECT_EQ(deallocs, 1);
 }
 
-TEST(ProtocolTest, CopyConstructionAllocs) {
+TEST(ProtocolTest, CopyConstruction) {
   static_assert(not std::is_nothrow_copy_constructible_v<TestProtocol>);
 
   unsigned allocs{};
@@ -104,7 +102,7 @@ TEST(ProtocolTest, CopyConstructionAllocs) {
   EXPECT_EQ(deallocs, 2);
 }
 
-TEST(ProtocolTest, CopyConstructionEqualAllocs) {
+TEST(ProtocolTest, CopyConstructionEqual) {
   unsigned allocs{};
   unsigned deallocs{};
   {
@@ -121,7 +119,7 @@ TEST(ProtocolTest, CopyConstructionEqualAllocs) {
   EXPECT_EQ(deallocs, 2);
 }
 
-TEST(ProtocolTest, CopyConstructionUnequalAllocs) {
+TEST(ProtocolTest, CopyConstructionUnequal) {
   unsigned allocs1{};
   unsigned deallocs1{};
 
@@ -143,7 +141,7 @@ TEST(ProtocolTest, CopyConstructionUnequalAllocs) {
   EXPECT_EQ(deallocs2, 1);
 }
 
-TEST(ProtocolTest, CopyAssignmentEqualAllocs) {
+TEST(ProtocolTest, CopyAssignmentEqual) {
   unsigned allocs{};
   unsigned deallocs{};
   {
@@ -162,7 +160,7 @@ TEST(ProtocolTest, CopyAssignmentEqualAllocs) {
   EXPECT_EQ(deallocs, 3);
 }
 
-TEST(ProtocolTest, CopyAssignmentUnequalAllocs) {
+TEST(ProtocolTest, CopyAssignmentUnequal) {
   unsigned allocs1{};
   unsigned deallocs1{};
 
@@ -187,7 +185,7 @@ TEST(ProtocolTest, CopyAssignmentUnequalAllocs) {
   EXPECT_EQ(deallocs2, 1);
 }
 
-TEST(ProtocolTest, MoveConstructionAllocs) {
+TEST(ProtocolTest, MoveConstruction) {
   static_assert(std::is_nothrow_move_constructible_v<TestProtocol>);
 
   unsigned allocs{};
@@ -204,8 +202,10 @@ TEST(ProtocolTest, MoveConstructionAllocs) {
   EXPECT_EQ(deallocs, 1);
 }
 
-TEST(ProtocolTest, MoveConstructionEqualAllocs) {
-  static_assert(not std::is_nothrow_constructible_v<TestProtocol, std::allocator_arg_t, TestAlloc, TestProtocol&&>);
+TEST(ProtocolTest, MoveConstructionEqual) {
+  static_assert(
+      not std::is_nothrow_constructible_v<TestProtocol, std::allocator_arg_t,
+                                          TestAlloc, TestProtocol&&>);
 
   unsigned allocs{};
   unsigned deallocs{};
@@ -223,7 +223,7 @@ TEST(ProtocolTest, MoveConstructionEqualAllocs) {
   EXPECT_EQ(deallocs, 1);
 }
 
-TEST(ProtocolTest, MoveConstructionUnequalAllocs) {
+TEST(ProtocolTest, MoveConstructionUnequal) {
   unsigned allocs1{};
   unsigned deallocs1{};
 
@@ -238,21 +238,20 @@ TEST(ProtocolTest, MoveConstructionUnequalAllocs) {
 
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
-    EXPECT_EQ(deallocs1, 0);
+    EXPECT_EQ(deallocs1, 1);
     EXPECT_EQ(deallocs2, 0);
   }
-  EXPECT_EQ(deallocs1, 1);
   EXPECT_EQ(deallocs2, 1);
 }
 
-TEST(ProtocolTest, MoveAssignmentEqualAllocs) {
+TEST(ProtocolTest, MoveAssignmentEqual) {
   unsigned allocs{};
   unsigned deallocs{};
   {
     TestAlloc alloc{&allocs, &deallocs};
 
     TestProtocol p1{std::allocator_arg, alloc, Tester{30}};
-    TestProtocol p2{Tester{40}};
+    TestProtocol p2{std::allocator_arg, alloc, Tester{40}};
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
 
@@ -264,7 +263,7 @@ TEST(ProtocolTest, MoveAssignmentEqualAllocs) {
   EXPECT_EQ(deallocs, 2);
 }
 
-TEST(ProtocolTest, MoveAssignmentUnequalAllocs) {
+TEST(ProtocolTest, MoveAssignmentUnequal) {
   unsigned allocs1{};
   unsigned deallocs1{};
 
@@ -289,4 +288,173 @@ TEST(ProtocolTest, MoveAssignmentUnequalAllocs) {
   EXPECT_EQ(deallocs2, 1);
 }
 
+TEST(ProtocolTest, SwapEqual) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  {
+    TestAlloc alloc1{&allocs, &deallocs};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+
+    TestAlloc alloc2{&allocs, &deallocs};
+    TestProtocol p2{std::allocator_arg, alloc2, p1};
+
+    EXPECT_EQ(allocs, 2);
+
+    std::swap(p1, p2);
+
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(deallocs, 0);
+
+    EXPECT_EQ(p1.get_allocator(), alloc1);
+    EXPECT_EQ(p2.get_allocator(), alloc2);
+  }
+  EXPECT_EQ(deallocs, 2);
 }
+
+// Tests that swap fails gracefully with an assert in debug mode.
+// In release mode, this is undefined behavior.
+#if (defined(_MSC_VER) && defined(_DEBUG)) || (!defined(NDEBUG))
+TEST(ProtocolTest, SwapUnequal) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+  TestAlloc alloc1{&allocs1, &deallocs1};
+  TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+  TestAlloc alloc2{&allocs2, &deallocs2};
+  TestProtocol p2{std::allocator_arg, alloc2, p1};
+
+  using std::swap;
+  EXPECT_DEATH(swap(p1, p2));
+}
+#endif
+
+template <typename T>
+struct PoccaAllocator : xyz::TrackingAllocator<T> {
+  using xyz::TrackingAllocator<T>::TrackingAllocator;
+  using propagate_on_container_copy_assignment = std::true_type;
+
+  template <typename Other>
+  struct rebind {
+    using other = PoccaAllocator<Other>;
+  }
+};
+
+TEST(ProtocolTest, CopyAssignmentUnequalPocca) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+
+  {
+    PoccaAllocator<std::byte> alloc1{&allocs1, &deallocs1};
+    xyz::protocol<Blank, PoccaAllocator<std::byte>> p1{std::allocator_arg,
+                                                       alloc1, Tester{0}};
+
+    PoccaAllocator<std::byte> alloc2{&allocs2, &deallocs2};
+    xyz::protocol<Blank, PoccaAllocator<std::byte>> p2{std::allocator_arg,
+                                                       alloc2, Tester{0}};
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+
+    p1 = p2;
+    EXPECT_EQ(allocs1, 2);
+    EXPECT_EQ(deallocs1, 1);
+    EXPECT_EQ(deallocs2, 1);
+  }
+
+  EXPECT_EQ(deallocs1, 2);
+}
+
+template <typename T>
+struct PocmaAllocator : xyz::TrackingAllocator<T> {
+  using xyz::TrackingAllocator<T>::TrackingAllocator;
+  using propagate_on_container_move_assignment = std::true_type;
+
+  template <typename Other>
+  struct rebind {
+    using other = PocmaAllocator<Other>;
+  }
+};
+
+TEST(ProtocolTest, MoveAssignmentUnequalPocma) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+
+  {
+    PocmaAllocator<std::byte> alloc1{&allocs1, &deallocs1};
+    xyz::protocol<Blank, PocmaAllocator<std::byte>> p1{std::allocator_arg,
+                                                       alloc1, Tester{0}};
+
+    PocmaAllocator<std::byte> alloc2{&allocs2, &deallocs2};
+    xyz::protocol<Blank, PocmaAllocator<std::byte>> p2{std::allocator_arg,
+                                                       alloc2, Tester{10}};
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+
+    p1 = std::move(p2);
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(deallocs1, 1);
+
+    EXPECT_EQ(allocs2, 1);
+    EXPECT_EQ(deallocs2, 0);
+  }
+
+  EXPECT_EQ(deallocs2, 1);
+}
+
+template <typename T>
+struct PocsAllocator : xyz::TrackingAllocator<T> {
+  using xyz::TrackingAllocator<T>::TrackingAllocator;
+  using propagate_on_container_swap = std::true_type;
+
+  template <typename Other>
+  struct rebind {
+    using other = PocsAllocator<Other>;
+  }
+};
+
+TEST(ProtocolTest, SwapUnequalPocs) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+  {
+    PocsAllocator<std::byte> alloc1{&allocs1, &deallocs1};
+    xyz::protocol<Blank, PocsAllocator<std::byte>> p1{std::allocator_arg, alloc1,
+                                                       Tester{0}};
+  
+    PocsAllocator<std::byte> alloc2{&allocs2, &deallocs2};
+    xyz::protocol<Blank, PocsAllocator<std::byte>> p2{std::allocator_arg, alloc2,
+                                                       Tester{10}};
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+
+    using std::swap;
+    swap(alloc1, alloc2);
+
+    EXPECT_EQ(p1.get_allocator(), alloc2);
+    EXPECT_EQ(p2.get_allocator(), alloc1);
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+  }
+
+  EXPECT_EQ(deallocs1, 1);
+  EXPECT_EQ(deallocs2, 1);
+}
+
+// TODO: Add exception checks
+
+// TODO: Add tests with PMR / STL
+
+}  // namespace

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -657,8 +657,13 @@ TEST(ProtocolTest, SwapUnequalPocs) {
   EXPECT_EQ(deallocs2, 1);
 }
 
+// A simple exception to test catching.
 struct TestException : std::bad_alloc {};
 
+// An extension of tracking allocator that holds a pointer to
+// a flag indicating whether or not it should throw upon allocation.
+// Tests can pass in should_throw and change its value to exercise exception
+// safety.
 template <typename T>
 struct ThrowingAllocator : xyz::TrackingAllocator<T> {
   const bool* should_throw_;
@@ -692,6 +697,7 @@ TEST(ProtocolTest, ConstructionException) {
   ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
   EXPECT_THROW(ThrowingProtocol{std::allocator_arg, alloc, Tester{0}},
                TestException);
+  // alloc threw before any allocations were performed.
   EXPECT_EQ(allocs, 0);
   EXPECT_EQ(deallocs, 0);
 }
@@ -705,10 +711,13 @@ TEST(ProtocolTest, CopyConstructionException) {
 
     ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
     ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
+    // p1 was allocated safely.
     EXPECT_EQ(allocs, 1);
 
     should_throw = true;
+    // We attempt to copy p1, and now throw during allocation.
     EXPECT_THROW(ThrowingProtocol{p1}, TestException);
+    // p1 should be unchanged.
     EXPECT_EQ(p1.value(), 10);
   }
 
@@ -722,6 +731,7 @@ TEST(ProtocolTest, CopyAssignmentException) {
   {
     bool should_throw{false};
 
+    // p1 and p2 are both constructed without issue.
     ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
     ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
     ThrowingProtocol p2{std::allocator_arg, alloc, Tester{20}};
@@ -729,9 +739,12 @@ TEST(ProtocolTest, CopyAssignmentException) {
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
 
+    // Copy assignment triggers an allocation and throws an exception.
     should_throw = true;
     EXPECT_THROW(p2 = p1, TestException);
 
+    // Both values are left in their original states. This is the strong
+    // exception guarantee.
     EXPECT_EQ(p1.value(), 10);
     EXPECT_EQ(p2.value(), 20);
   }
@@ -742,19 +755,18 @@ TEST(ProtocolTest, EqualMoveConstructionNoException) {
   unsigned allocs = 0;
   unsigned deallocs = 0;
 
-  {
-    bool should_throw{false};
+  bool should_throw{false};
 
-    ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
-    ThrowingProtocol p1{std::allocator_arg, alloc, Tester{15}};
-    EXPECT_EQ(allocs, 1);
+  ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
+  ThrowingProtocol p1{std::allocator_arg, alloc, Tester{15}};
+  EXPECT_EQ(allocs, 1);
 
-    should_throw = true;
-    ThrowingProtocol p2{std::move(p1)};  // Does not throw.
-    EXPECT_EQ(allocs, 1);
-  }
-
-  EXPECT_EQ(deallocs, 1);
+  should_throw = true;
+  // Even though allocation will throw, moving from p1 should
+  // not require any allocation and therefore not throw.
+  EXPECT_NO_THROW(ThrowingProtocol{std::move(p1)});
+  EXPECT_EQ(allocs, 1);
+  EXPECT_EQ(deallocs, 1); 
 }
 
 TEST(ProtocolTest, UnequalMoveConstructionException) {
@@ -772,6 +784,9 @@ TEST(ProtocolTest, UnequalMoveConstructionException) {
 
     should_throw = true;
     ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw};
+
+    // We now construct with an alloc2, which is not equal to alloc1. This requires
+    // us to allocate space and then move from p1, which triggers an exception.
     EXPECT_THROW(ThrowingProtocol{std::allocator_arg, alloc2, std::move(p1)},
                  TestException);
 
@@ -779,6 +794,8 @@ TEST(ProtocolTest, UnequalMoveConstructionException) {
     EXPECT_EQ(deallocs1, 0);
     EXPECT_EQ(allocs2, 0);
 
+    // p1 should be unmodified.
+    ASSERT_FALSE(p1.valueless_after_move());
     EXPECT_EQ(p1.value(), 25);
   }
 
@@ -797,8 +814,10 @@ TEST(ProtocolTest, EqualMoveAssignmentNoException) {
     ThrowingProtocol p2{std::allocator_arg, alloc, Tester{35}};
     EXPECT_EQ(allocs, 2);
 
+    // When p1 and p2 have equal allocators, move assignment should
+    // not throw.
     should_throw = true;
-    p1 = std::move(p2);  // Does not throw.
+    p1 = std::move(p2);
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 1);
   }
@@ -826,11 +845,17 @@ TEST(ProtocolTest, UnequalMoveAssignmentException) {
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
 
+    // Move assignment with unequal allocators requires new allocation.
+    // This results in an exception being thrown.
     should_throw1 = true;
     EXPECT_THROW(p1 = std::move(p2), TestException);
-
     EXPECT_EQ(deallocs2, 0);
+    
+    // p1 should be valid after the exception is caught.
     EXPECT_EQ(p1.value(), 25);
+
+    // p2 should not have been destroyed.
+    EXPECT_FALSE(p2.valueless_after_move());
     EXPECT_EQ(p2.value(), 55);
   }
 

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -334,7 +334,8 @@ TEST(ProtocolTest, NarrowingCopyConstruction) {
   unsigned deallocs{};
   {
     TestAlloc alloc1{&allocs, &deallocs};
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
     xyz::protocol<Blank, TestAlloc> p2{p1};
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
@@ -353,7 +354,8 @@ TEST(ProtocolTest, NarrowingCopyConstructionUnequal) {
     TestAlloc alloc1{&allocs1, &deallocs1};
     TestAlloc alloc2{&allocs2, &deallocs2};
 
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
     xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, p1};
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
@@ -367,7 +369,8 @@ TEST(ProtocolTest, NarrowingMoveConstruction) {
   unsigned deallocs{};
   {
     TestAlloc alloc1{&allocs, &deallocs};
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
     xyz::protocol<Blank, TestAlloc> p2{std::move(p1)};
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
@@ -383,8 +386,10 @@ TEST(ProtocolTest, NarrowingMoveConstructionEqual) {
     TestAlloc alloc1{&allocs, &deallocs};
     TestAlloc alloc2{&allocs, &deallocs};
 
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, std::move(p1)};
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
+                                       std::move(p1)};
     EXPECT_EQ(allocs, 1);
   }
   EXPECT_EQ(deallocs, 1);
@@ -401,8 +406,10 @@ TEST(ProtocolTest, NarrowingMoveConstructionUnequal) {
     TestAlloc alloc1{&allocs1, &deallocs1};
     TestAlloc alloc2{&allocs2, &deallocs2};
 
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1, Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, std::move(p1)};
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
+                                       std::move(p1)};
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
   }
@@ -425,7 +432,8 @@ TEST(ProtocolTest, SwapUnequal) {
   TestProtocol p2{std::allocator_arg, alloc2, p1};
 
   using std::swap;
-  EXPECT_DEATH(swap(p1, p2), "allocators must compare equal or propagate on swap");
+  EXPECT_DEATH(swap(p1, p2),
+               "allocators must compare equal or propagate on swap");
 }
 #endif
 
@@ -647,7 +655,7 @@ TEST(ProtocolTest, EqualMoveConstructionNoException) {
     EXPECT_EQ(allocs, 1);
 
     should_throw = true;
-    ThrowingProtocol p2{std::move(p1)}; // Does not throw.
+    ThrowingProtocol p2{std::move(p1)};  // Does not throw.
     EXPECT_EQ(allocs, 1);
   }
 
@@ -666,10 +674,11 @@ TEST(ProtocolTest, UnequalMoveConstructionException) {
 
     ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw};
     ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
-   
+
     should_throw = true;
     ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw};
-    EXPECT_THROW(ThrowingProtocol{std::allocator_arg, alloc2, std::move(p1)}, TestException);
+    EXPECT_THROW(ThrowingProtocol{std::allocator_arg, alloc2, std::move(p1)},
+                 TestException);
 
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(deallocs1, 0);
@@ -694,7 +703,7 @@ TEST(ProtocolTest, EqualMoveAssignmentNoException) {
     EXPECT_EQ(allocs, 2);
 
     should_throw = true;
-    p1 = std::move(p2); // Does not throw.
+    p1 = std::move(p2);  // Does not throw.
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 1);
   }
@@ -715,7 +724,7 @@ TEST(ProtocolTest, UnequalMoveAssignmentException) {
 
     ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw1};
     ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
-   
+
     ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw2};
     ThrowingProtocol p2{std::allocator_arg, alloc2, Tester{55}};
 

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -766,7 +766,7 @@ TEST(ProtocolTest, EqualMoveConstructionNoException) {
   // not require any allocation and therefore not throw.
   EXPECT_NO_THROW(ThrowingProtocol{std::move(p1)});
   EXPECT_EQ(allocs, 1);
-  EXPECT_EQ(deallocs, 1); 
+  EXPECT_EQ(deallocs, 1);
 }
 
 TEST(ProtocolTest, UnequalMoveConstructionException) {
@@ -785,8 +785,9 @@ TEST(ProtocolTest, UnequalMoveConstructionException) {
     should_throw = true;
     ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw};
 
-    // We now construct with an alloc2, which is not equal to alloc1. This requires
-    // us to allocate space and then move from p1, which triggers an exception.
+    // We now construct with an alloc2, which is not equal to alloc1. This
+    // requires us to allocate space and then move from p1, which triggers an
+    // exception.
     EXPECT_THROW(ThrowingProtocol{std::allocator_arg, alloc2, std::move(p1)},
                  TestException);
 
@@ -850,7 +851,7 @@ TEST(ProtocolTest, UnequalMoveAssignmentException) {
     should_throw1 = true;
     EXPECT_THROW(p1 = std::move(p2), TestException);
     EXPECT_EQ(deallocs2, 0);
-    
+
     // p1 should be valid after the exception is caught.
     EXPECT_EQ(p1.value(), 25);
 

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -31,15 +31,19 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 namespace {
 
+// A simple interface to test protocol with.
 struct IntLike {
   int value() const noexcept;
 };
 
+// A narrower interface than IntLike, so we can
+// test narrowing constructors.
 struct Blank {};
 
 using TestAlloc = xyz::TrackingAllocator<std::byte>;
 using TestProtocol = xyz::protocol<IntLike, TestAlloc>;
 
+// A simple test class that we will place in protocol.
 class Tester {
   int val_;
 
@@ -52,6 +56,7 @@ class Tester {
  public:
   Tester(int value) noexcept : val_(value) {}
 
+  // Just so we can exercise protocol's in-place init list constructor.
   Tester(std::initializer_list<int>) noexcept {}
 
   int value() const noexcept { return val_; }
@@ -71,6 +76,7 @@ TEST(ProtocolTest, Construction) {
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
   }
+  // Memory is cleaned up after the block scope closes.
   EXPECT_EQ(allocs, 1);
   EXPECT_EQ(deallocs, 1);
 }
@@ -113,7 +119,7 @@ TEST(ProtocolTest, CopyConstruction) {
     TestAlloc alloc{&allocs, &deallocs};
     TestProtocol p1{std::allocator_arg, alloc, Tester{25}};
     xyz::protocol p2{p1};
-    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(allocs, 2);  // Once for p1, and once for p2.
     EXPECT_EQ(deallocs, 0);
   }
   EXPECT_EQ(allocs, 2);
@@ -124,12 +130,18 @@ TEST(ProtocolTest, CopyConstructionEqual) {
   unsigned allocs = 0;
   unsigned deallocs = 0;
   {
+    // TestAllocs are considered equivalent if they point to
+    // the same allocs and deallocs variables. Therefore,
+    // alloc1 == alloc2 here.
     TestAlloc alloc1{&allocs, &deallocs};
+    TestAlloc alloc2{&allocs, &deallocs};
+    ASSERT_EQ(alloc1, alloc2);
+
     TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
 
-    TestAlloc alloc2{&allocs, &deallocs};
     TestProtocol p2{std::allocator_arg, alloc2, p1};
 
+    // Both alloc1 and alloc2 point at the same counter.
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
   }
@@ -144,14 +156,18 @@ TEST(ProtocolTest, CopyConstructionUnequal) {
   unsigned allocs2 = 0;
   unsigned deallocs2 = 0;
   {
+    // alloc1 != alloc2 now, so p1 and p2 should allocate with
+    // their own respective allocators.
     TestAlloc alloc1{&allocs1, &deallocs1};
-    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
-
     TestAlloc alloc2{&allocs2, &deallocs2};
+    ASSERT_NE(alloc1, alloc2);
+
+    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+    // p2 copies from p1, but allocates using alloc2.
     TestProtocol p2{std::allocator_arg, alloc2, p1};
 
-    EXPECT_EQ(allocs1, 1);
-    EXPECT_EQ(allocs2, 1);
+    EXPECT_EQ(allocs1, 1);  // From p1.
+    EXPECT_EQ(allocs2, 1);  // From p2.
     EXPECT_EQ(deallocs1, 0);
     EXPECT_EQ(deallocs2, 0);
   }
@@ -171,7 +187,10 @@ TEST(ProtocolTest, CopyAssignmentEqual) {
     EXPECT_EQ(deallocs, 0);
 
     p1 = p2;
+    // One allocation for constructing p1; one for p2; and
+    // one for copy assignment.
     EXPECT_EQ(allocs, 3);
+    // p1's original state should have been deallocated.
     EXPECT_EQ(deallocs, 1);
   }
   EXPECT_EQ(allocs, 3);
@@ -186,17 +205,23 @@ TEST(ProtocolTest, CopyAssignmentUnequal) {
   unsigned deallocs2 = 0;
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
-    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
-
     TestAlloc alloc2{&allocs2, &deallocs2};
-    TestProtocol p2{std::allocator_arg, alloc2, p1};
+    ASSERT_NE(alloc1, alloc2);
+
+    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+    TestProtocol p2{std::allocator_arg, alloc2, Tester{200}};
 
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
 
     p1 = p2;
 
+    // The new copy is created with alloc1, and the original
+    // p1 is deallocated with alloc1.
     EXPECT_EQ(allocs1, 2);
+    EXPECT_EQ(deallocs1, 1);
+
+    // alloc2 was never used for additional memory.
     EXPECT_EQ(allocs2, 1);
   }
   EXPECT_EQ(deallocs1, 2);
@@ -204,6 +229,7 @@ TEST(ProtocolTest, CopyAssignmentUnequal) {
 }
 
 TEST(ProtocolTest, MoveConstruction) {
+  // protocol should always be nothrow move constructible.
   static_assert(std::is_nothrow_move_constructible_v<TestProtocol>);
 
   unsigned allocs = 0;
@@ -212,8 +238,10 @@ TEST(ProtocolTest, MoveConstruction) {
     TestAlloc alloc{&allocs, &deallocs};
 
     TestProtocol p1{std::allocator_arg, alloc, Tester{50}};
-    xyz::protocol p2{std::move(p1)};
     EXPECT_EQ(allocs, 1);
+
+    TestProtocol p2{std::move(p1)};
+    EXPECT_EQ(allocs, 1);  // No new allocations.
     EXPECT_EQ(deallocs, 0);
   }
   EXPECT_EQ(allocs, 1);
@@ -234,6 +262,8 @@ TEST(ProtocolTest, MoveConstructionEqual) {
     TestAlloc alloc2{&allocs, &deallocs};
     TestProtocol p2{std::allocator_arg, alloc2, std::move(p1)};
 
+    // alloc1 == alloc2, so no new memory needs to be allocated by
+    // p2.
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
   }
@@ -250,19 +280,28 @@ TEST(ProtocolTest, MoveConstructionUnequal) {
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
     TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+    EXPECT_EQ(allocs1, 1);
 
+    // alloc2 != alloc1. We cannot perform a simple pointer-swap
+    // in this case, and must reallocate and move the underlying
+    // memory.
     TestAlloc alloc2{&allocs2, &deallocs2};
     TestProtocol p2{std::allocator_arg, alloc2, std::move(p1)};
-
-    EXPECT_EQ(allocs1, 1);
+    // A new allocation is performed by alloc2.
     EXPECT_EQ(allocs2, 1);
+    // p1 is moved-from and therefore has deallocated its memory.
     EXPECT_EQ(deallocs1, 1);
+
     EXPECT_EQ(deallocs2, 0);
   }
   EXPECT_EQ(deallocs2, 1);
 }
 
 TEST(ProtocolTest, MoveAssignmentEqual) {
+  // Since TestAllocs are not always equivalent and do not propagate on move,
+  // operator=(TestProtocol&&) should not be noexcept.
+  static_assert(not std::is_nothrow_move_assignable_v<TestProtocol>);
+
   unsigned allocs = 0;
   unsigned deallocs = 0;
   {
@@ -273,9 +312,10 @@ TEST(ProtocolTest, MoveAssignmentEqual) {
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
 
+    // Both use the same allocator, so moving is a simple pointer swap.
     p1 = std::move(p2);
     EXPECT_EQ(allocs, 2);
-    EXPECT_EQ(deallocs, 1);
+    EXPECT_EQ(deallocs, 1);  // p2 has been deallocated.
   }
   EXPECT_EQ(allocs, 2);
   EXPECT_EQ(deallocs, 2);
@@ -297,13 +337,15 @@ TEST(ProtocolTest, MoveAssignmentUnequal) {
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
 
+    // alloc1 != alloc2, so the underlying type must be moved into
+    // a new storage.
     p1 = std::move(p2);
 
+    // Allocates for original construction, and once for move assignment.
     EXPECT_EQ(allocs1, 2);
-    EXPECT_EQ(allocs2, 1);
+    EXPECT_EQ(deallocs2, 1);
   }
   EXPECT_EQ(deallocs1, 2);
-  EXPECT_EQ(deallocs2, 1);
 }
 
 TEST(ProtocolTest, SwapEqual) {
@@ -318,103 +360,19 @@ TEST(ProtocolTest, SwapEqual) {
 
     EXPECT_EQ(allocs, 2);
 
-    std::swap(p1, p2);
+    // alloc1 == alloc2, so p1 and p2 should swap safely.
+    using std::swap;
+    swap(p1, p2);
 
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
 
+    // Both keep their original allocator, but now manage
+    // each other's memory.
     EXPECT_EQ(p1.get_allocator(), alloc1);
     EXPECT_EQ(p2.get_allocator(), alloc2);
   }
   EXPECT_EQ(deallocs, 2);
-}
-
-TEST(ProtocolTest, NarrowingCopyConstruction) {
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
-  {
-    TestAlloc alloc1{&allocs, &deallocs};
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{p1};
-    EXPECT_EQ(allocs, 2);
-    EXPECT_EQ(deallocs, 0);
-  }
-  EXPECT_EQ(deallocs, 2);
-}
-
-TEST(ProtocolTest, NarrowingCopyConstructionUnequal) {
-  unsigned allocs1 = 0;
-  unsigned deallocs1 = 0;
-
-  unsigned allocs2 = 0;
-  unsigned deallocs2 = 0;
-
-  {
-    TestAlloc alloc1{&allocs1, &deallocs1};
-    TestAlloc alloc2{&allocs2, &deallocs2};
-
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, p1};
-    EXPECT_EQ(allocs1, 1);
-    EXPECT_EQ(allocs2, 1);
-  }
-  EXPECT_EQ(deallocs1, 1);
-  EXPECT_EQ(deallocs2, 1);
-}
-
-TEST(ProtocolTest, NarrowingMoveConstruction) {
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
-  {
-    TestAlloc alloc1{&allocs, &deallocs};
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::move(p1)};
-    EXPECT_EQ(allocs, 1);
-    EXPECT_EQ(deallocs, 0);
-  }
-  EXPECT_EQ(deallocs, 1);
-}
-
-TEST(ProtocolTest, NarrowingMoveConstructionEqual) {
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
-
-  {
-    TestAlloc alloc1{&allocs, &deallocs};
-    TestAlloc alloc2{&allocs, &deallocs};
-
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
-                                       std::move(p1)};
-    EXPECT_EQ(allocs, 1);
-  }
-  EXPECT_EQ(deallocs, 1);
-}
-
-TEST(ProtocolTest, NarrowingMoveConstructionUnequal) {
-  unsigned allocs1 = 0;
-  unsigned deallocs1 = 0;
-
-  unsigned allocs2 = 0;
-  unsigned deallocs2 = 0;
-
-  {
-    TestAlloc alloc1{&allocs1, &deallocs1};
-    TestAlloc alloc2{&allocs2, &deallocs2};
-
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
-                                       std::move(p1)};
-    EXPECT_EQ(allocs1, 1);
-    EXPECT_EQ(allocs2, 1);
-  }
-  EXPECT_EQ(deallocs1, 1);
-  EXPECT_EQ(deallocs2, 1);
 }
 
 // Tests that swap fails gracefully with an assert in debug mode.
@@ -436,6 +394,115 @@ TEST(ProtocolTest, SwapUnequal) {
                "allocators must compare equal or propagate on swap");
 }
 #endif
+
+TEST(ProtocolTest, NarrowingCopyConstruction) {
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
+  {
+    TestAlloc alloc1{&allocs, &deallocs};
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
+    // Blank is a subset of IntLike.
+    xyz::protocol<Blank, TestAlloc> p2{p1};
+    // This is a deep copy still, so space must be allocated once for
+    // p1 and once for p2.
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(deallocs, 2);
+}
+
+TEST(ProtocolTest, NarrowingCopyConstructionUnequal) {
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
+
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
+
+  {
+    TestAlloc alloc1{&allocs1, &deallocs1};
+    TestAlloc alloc2{&allocs2, &deallocs2};
+
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, p1};
+    EXPECT_EQ(allocs1, 1);  // Allocated p1.
+    EXPECT_EQ(allocs2, 1);  // Allocated p2.
+  }
+  EXPECT_EQ(deallocs1, 1);
+  EXPECT_EQ(deallocs2, 1);
+}
+
+TEST(ProtocolTest, NarrowingMoveConstruction) {
+  // Narrowing move construction should always be noexcept.
+  static_assert(
+      std::is_nothrow_constructible<xyz::protocol<IntLike, TestAlloc>,
+                                    xyz::protocol<Blank, TestAlloc>&&>);
+
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
+  {
+    TestAlloc alloc1{&allocs, &deallocs};
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::move(p1)};
+    // Even though the interfaces are different, the allocators are the
+    // same. Move construction is a pointer swap.
+    EXPECT_EQ(allocs, 1);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, NarrowingMoveConstructionEqual) {
+  // TestAllocs are not always equal, so allocator-aware narrowing move
+  // construction can potentially throw.
+  static_assert(
+      not std::is_nothrow_constructible<xyz::protocol<IntLike, TestAlloc>,
+                                        std::allocator_arg_t, TestAlloc,
+                                        xyz::protocol<Blank, TestAlloc>&&>);
+
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
+
+  {
+    TestAlloc alloc1{&allocs, &deallocs};
+    TestAlloc alloc2{&allocs, &deallocs};
+
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
+                                       std::move(p1)};
+    // Even though we explicitly provide an allocator, they both
+    // compare equal, so move construction is still a pointer swap.
+    EXPECT_EQ(allocs, 1);
+  }
+  EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, NarrowingMoveConstructionUnequal) {
+  unsigned allocs1 = 0;
+  unsigned deallocs1 = 0;
+
+  unsigned allocs2 = 0;
+  unsigned deallocs2 = 0;
+
+  {
+    TestAlloc alloc1{&allocs1, &deallocs1};
+    TestAlloc alloc2{&allocs2, &deallocs2};
+
+    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+                                         Tester{25}};
+    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
+                                       std::move(p1)};
+    // alloc1 != alloc2, so we must perform a new allocation for p2
+    // and move the underlying data.
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+  }
+  EXPECT_EQ(deallocs1, 1);
+  EXPECT_EQ(deallocs2, 1);
+}
 
 template <typename T>
 struct PoccaAllocator : xyz::TrackingAllocator<T> {

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -1,0 +1,30 @@
+#include "protocol.h"
+#include "tagged_allocator.h"
+#include "tracking_allocator.h"
+
+#include <gtest/gtest.h>
+
+struct Blank {};
+struct NonCopyable {
+    NonCopyable(const NonCopyable&) = delete;
+    NonCopyable& operator=(const NonCopyable&) = delete;
+
+    NonCopyable(NonCopyable&&) = default;
+    NonCopyable& operator=(NonCopyable&&) = default;
+
+    ~NonCopyable() = default;
+};
+
+TEST(ProtocolTest, ConstructionAllocations) {
+    unsigned allocs{};
+    unsigned deallocs{};
+    {
+        xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
+        xyz::protocol<Blank, decltype(alloc)> p{std::allocator_arg, alloc, 15};
+        EXPECT_EQ(allocs, 1);
+        EXPECT_EQ(deallocs, 0);
+    }
+    EXPECT_EQ(allocs, 1);
+    EXPECT_EQ(deallocs, 1);
+}
+

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -9,34 +9,28 @@
 
 namespace {
 
-struct Blank {};
-
-struct NonCopyable {
-  NonCopyable(const NonCopyable&) = delete;
-  NonCopyable& operator=(const NonCopyable&) = delete;
-
-  NonCopyable(NonCopyable&&) = default;
-  NonCopyable& operator=(NonCopyable&&) = default;
-
-  ~NonCopyable() = default;
+struct IntLike {
+  int value() const noexcept;
 };
 
 using TestAlloc = xyz::TrackingAllocator<std::byte>;
-using TestProtocol = xyz::protocol<Blank, TestAlloc>;
+using TestProtocol = xyz::protocol<IntLike, TestAlloc>;
 
-struct Tester {
-  int val;
+class Tester {
+  int val_;
 
-  Tester(int value) noexcept : val(value) {}
+  // protocol should probably implement small buffer optimization, and therefore
+  // we may find there are fewer allocations than these tests suggest. To
+  // sidestep this, we can use a type that is guaranteed to be larger than
+  // protocol.
+  std::array<std::byte, sizeof(TestProtocol)> padding_;
+
+ public:
+  Tester(int value) noexcept : val_(value) {}
 
   Tester(std::initializer_list<int>) noexcept {}
 
- private:
-  // protocol should probably
-  // implement small buffer optimization, and therefore we may find there are
-  // fewer allocations than these tests suggest. To sidestep this, we can use
-  // a type that is guaranteed to be larger than protocol.
-  std::array<std::byte, sizeof(P)> padding;
+  int value() const noexcept { return val_; }
 };
 
 TEST(ProtocolTest, Construction) {
@@ -350,12 +344,12 @@ TEST(ProtocolTest, CopyAssignmentUnequalPocca) {
 
   {
     PoccaAllocator<std::byte> alloc1{&allocs1, &deallocs1};
-    xyz::protocol<Blank, PoccaAllocator<std::byte>> p1{std::allocator_arg,
-                                                       alloc1, Tester{0}};
+    xyz::protocol<IntLike, PoccaAllocator<std::byte>> p1{std::allocator_arg,
+                                                         alloc1, Tester{0}};
 
     PoccaAllocator<std::byte> alloc2{&allocs2, &deallocs2};
-    xyz::protocol<Blank, PoccaAllocator<std::byte>> p2{std::allocator_arg,
-                                                       alloc2, Tester{0}};
+    xyz::protocol<IntLike, PoccaAllocator<std::byte>> p2{std::allocator_arg,
+                                                         alloc2, Tester{0}};
 
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
@@ -389,12 +383,12 @@ TEST(ProtocolTest, MoveAssignmentUnequalPocma) {
 
   {
     PocmaAllocator<std::byte> alloc1{&allocs1, &deallocs1};
-    xyz::protocol<Blank, PocmaAllocator<std::byte>> p1{std::allocator_arg,
-                                                       alloc1, Tester{0}};
+    xyz::protocol<IntLike, PocmaAllocator<std::byte>> p1{std::allocator_arg,
+                                                         alloc1, Tester{0}};
 
     PocmaAllocator<std::byte> alloc2{&allocs2, &deallocs2};
-    xyz::protocol<Blank, PocmaAllocator<std::byte>> p2{std::allocator_arg,
-                                                       alloc2, Tester{10}};
+    xyz::protocol<IntLike, PocmaAllocator<std::byte>> p2{std::allocator_arg,
+                                                         alloc2, Tester{10}};
 
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
@@ -429,12 +423,12 @@ TEST(ProtocolTest, SwapUnequalPocs) {
   unsigned deallocs2{};
   {
     PocsAllocator<std::byte> alloc1{&allocs1, &deallocs1};
-    xyz::protocol<Blank, PocsAllocator<std::byte>> p1{std::allocator_arg, alloc1,
-                                                       Tester{0}};
-  
+    xyz::protocol<IntLike, PocsAllocator<std::byte>> p1{std::allocator_arg,
+                                                        alloc1, Tester{0}};
+
     PocsAllocator<std::byte> alloc2{&allocs2, &deallocs2};
-    xyz::protocol<Blank, PocsAllocator<std::byte>> p2{std::allocator_arg, alloc2,
-                                                       Tester{10}};
+    xyz::protocol<IntLike, PocsAllocator<std::byte>> p2{std::allocator_arg,
+                                                        alloc2, Tester{10}};
 
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
@@ -453,8 +447,186 @@ TEST(ProtocolTest, SwapUnequalPocs) {
   EXPECT_EQ(deallocs2, 1);
 }
 
-// TODO: Add exception checks
+struct TestException : std::bad_alloc {
+  const char* what() const noexcept override { return bad_alloc::what(); }
+};
 
-// TODO: Add tests with PMR / STL
+template <typename T>
+struct ThrowingAllocator : xyz::TrackingAllocator<T> {
+  const bool* should_throw_;
+
+  template <typename U>
+  struct rebind {
+    using other = ThrowingAllocator<T>;
+  };
+
+  ThrowingAllocator(unsigned* allocs, unsigned* deallocs,
+                    const bool* shouldThrow)
+      : TrackingAllocator(allocs, deallocs), should_throw_(shouldThrow) {}
+
+  T* allocate(std::size_t count) {
+    if (should_throw_) {
+      throw std::bad_alloc{};
+    }
+    TrackingAllocator::allocate();
+  }
+};
+
+using ThrowingAlloc = ThrowingAllocator<std::byte>;
+
+using ThrowingProtocol = xyz::protocol<IntLike, ThrowingAlloc>
+
+TEST(ProtocolTest, ConstructionException) {
+  unsigned allocs{};
+  unsigned deallocs{};
+  bool should_throw{true};
+
+  ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
+  EXPECT_THROW(ThrowingProtocol{std::allocator_arg, alloc, Tester{0}},
+               TestException);
+  EXPECT_EQ(allocs, 0);
+  EXPECT_EQ(deallocs, 0);
+}
+
+TEST(ProtocolTest, CopyConstructionException) {
+  unsigned allocs{};
+  unsigned deallocs{};
+
+  {
+    bool should_throw{false};
+
+    ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
+    ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
+    EXPECT_EQ(allocs, 1);
+
+    should_throw = true;
+    EXPECT_THROW(ThrowingProtocol{p1}, TestException);
+    EXPECT_EQ(p1.value(), 10);
+  }
+
+  EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, CopyAssignmentException) {
+  unsigned allocs{};
+  unsigned deallocs{};
+
+  {
+    bool should_throw{false};
+
+    ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
+    ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
+    ThrowingProtocol p2{std::allocator_arg, alloc, Tester{20}};
+
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(allocs, 0);
+
+    should_throw = true;
+    EXPECT_THROW(p2 = p1, TestException);
+
+    EXPECT_EQ(p1.value(), 10);
+    EXPECT_EQ(p2.value(), 10);
+  }
+  EXPECT_EQ(deallocs, 2);
+}
+
+TEST(ProtocolTest, EqualMoveConstructionNoException) {
+  unsigned allocs{};
+  unsigned deallocs{};
+
+  {
+    bool should_throw{false};
+
+    ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
+    ThrowingProtocol p1{std::allocator_arg, alloc, Tester{15}};
+    EXPECT_EQ(allocs, 1);
+
+    should_throw = true;
+    ThrowingProtocol p2{std::move(p1)}; // Does not throw.
+    EXPECT_EQ(allocs, 1);
+  }
+
+  EXPECT_EQ(deallocs, 1);
+}
+
+TEST(ProtocolTest, UnequalMoveConstructionException) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+
+  {
+    bool should_throw{false};
+
+    ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw};
+    ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
+   
+    should_throw = true;
+    ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw};
+    EXPECT_THROW(ThrowingProtocol{std::allocator_arg, alloc, std::move(p1)}, TestException);
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(deallocs1, 0);
+    EXPECT_EQ(allocs2, 0);
+
+    EXPECT_EQ(p1.value(), 25);
+  }
+
+  EXPECT_EQ(deallocs1, 1);
+}
+
+TEST(ProtocolTest, EqualMoveAssignmentNoException) {
+  unsigned allocs{};
+  unsigned deallocs{};
+
+  {
+    bool should_throw{false};
+
+    ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
+    ThrowingProtocol p1{std::allocator_arg, alloc, Tester{15}};
+    ThrowingProtocol p2{std::allocator_arg, alloc, Tester{35}};
+    EXPECT_EQ(allocs, 2);
+
+    should_throw = true;
+    p1 = std::move(p2); // Does not throw.
+    EXPECT_EQ(allocs, 2);
+    EXPECT_EQ(deallocs, 1);
+  }
+
+  EXPECT_EQ(deallocs, 2);
+}
+
+TEST(ProtocolTest, UnequalMoveAssignmentException) {
+  unsigned allocs1{};
+  unsigned deallocs1{};
+
+  unsigned allocs2{};
+  unsigned deallocs2{};
+
+  {
+    bool should_throw1{false};
+    bool should_throw2{false};
+
+    ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw1};
+    ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
+   
+    ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw2};
+    ThrowingProtocol p2{std::allocator_arg, alloc2, Tester{55}};
+
+    EXPECT_EQ(allocs1, 1);
+    EXPECT_EQ(allocs2, 1);
+
+    should_throw1 = true;
+    EXPECT_THROW(p1 = std::move(p2), TestException);
+
+    EXPECT_EQ(deallocs2, 0);
+    EXPECT_EQ(p1.value(), 25);
+    EXPECT_EQ(p2.value(), 55);
+  }
+
+  EXPECT_EQ(deallocs1, 1);
+  EXPECT_EQ(deallocs2, 1);
+}
 
 }  // namespace

--- a/reflection/tagged_allocator.h
+++ b/reflection/tagged_allocator.h
@@ -1,0 +1,81 @@
+/* Copyright (c) 2016 The Value Types Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+
+// Based on boilerplate from:
+// https://howardhinnant.github.io/allocator_boilerplate.html
+
+#ifndef XYZ_TAGGED_ALLOCATOR_H_
+#define XYZ_TAGGED_ALLOCATOR_H_
+
+#include <cstddef>
+#include <memory>
+#include <new>
+#include <utility>
+
+namespace xyz {
+
+template <typename T>
+struct TaggedAllocator {
+  using value_type = T;
+
+  size_t tag;
+
+  TaggedAllocator(size_t tag) : tag(tag) {}
+
+  template <typename U>
+  TaggedAllocator(const TaggedAllocator<U>& other) : tag(other.tag) {}
+
+  template <typename Other>
+  struct rebind {
+    using other = TaggedAllocator<Other>;
+  };
+
+  // clang 17 and 18 seem to need the `construct` function to be explicitly
+  // defined rather than having a default picked up from allocator traits. It
+  // does nothing special.
+  template <class U, class... Args>
+  void construct(U* p, Args&&... args) {
+    ::new (p) U(std::forward<Args>(args)...);
+  }
+
+  T* allocate(std::size_t n) {
+    std::allocator<T> default_allocator{};
+    return default_allocator.allocate(n);
+  }
+
+  void deallocate(T* p, std::size_t n) {
+    std::allocator<T> default_allocator{};
+    default_allocator.deallocate(p, n);
+  }
+
+  friend bool operator==(const TaggedAllocator& lhs,
+                         const TaggedAllocator& rhs) noexcept {
+    return lhs.tag == rhs.tag;
+  }
+
+  friend bool operator!=(const TaggedAllocator& lhs,
+                         const TaggedAllocator& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+};
+
+}  // namespace xyz
+
+#endif  // XYZ_TAGGED_ALLOCATOR_H_

--- a/reflection/tracking_allocator.h
+++ b/reflection/tracking_allocator.h
@@ -1,0 +1,75 @@
+/* Copyright (c) 2016 The Value Types Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+
+#ifndef XYZ_TRACKING_ALLOCATOR_H_
+#define XYZ_TRACKING_ALLOCATOR_H_
+
+#include <cstddef>
+#include <memory>
+
+namespace xyz {
+
+template <typename T>
+struct TrackingAllocator {
+  unsigned* alloc_counter_;
+  unsigned* dealloc_counter_;
+
+  TrackingAllocator(unsigned* alloc_counter, unsigned* dealloc_counter)
+      : alloc_counter_(alloc_counter), dealloc_counter_(dealloc_counter) {}
+
+  template <typename U>
+  TrackingAllocator(const TrackingAllocator<U>& other)
+      : alloc_counter_(other.alloc_counter_),
+        dealloc_counter_(other.dealloc_counter_) {}
+
+  using value_type = T;
+
+  template <typename Other>
+  struct rebind {
+    using other = TrackingAllocator<Other>;
+  };
+
+  T* allocate(std::size_t n) {
+    ++(*alloc_counter_);
+    std::allocator<T> default_allocator{};
+    return default_allocator.allocate(n);
+  }
+
+  void deallocate(T* p, std::size_t n) {
+    ++(*dealloc_counter_);
+    std::allocator<T> default_allocator{};
+    default_allocator.deallocate(p, n);
+  }
+
+  friend bool operator==(const TrackingAllocator& lhs,
+                         const TrackingAllocator& rhs) noexcept {
+    return lhs.alloc_counter_ == rhs.alloc_counter_ &&
+           lhs.dealloc_counter_ == rhs.dealloc_counter_;
+  }
+
+  friend bool operator!=(const TrackingAllocator& lhs,
+                         const TrackingAllocator& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+};
+
+}  // namespace xyz
+
+#endif  // XYZ_TRACKING_ALLOCATOR_H_


### PR DESCRIPTION
Adds a test suite for the allocator conformance of `protocol`, based on tests from [indirect and polymorphic](https://github.com/jbcoe/value_types). 

Closes #143 