### PR TITLE
Reduce clang-tidy noise from checks the project does not need

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,23 @@
+# Checks are enabled with '*' and then opted out. Rationale for the less
+# obvious exclusions at the end of the list:
+#
+# - cppcoreguidelines-avoid-magic-numbers: alias of readability-magic-numbers,
+#   which is already disabled.
+# - readability-convert-member-functions-to-static: interface structs and
+#   conforming types must have non-static member functions; that is the whole
+#   point of structural subtyping.
+# - google-explicit-constructor, hicpp-explicit-conversions: implicit
+#   construction of protocol from a conforming type is by design.
+# - misc-const-correctness, modernize-use-nodiscard: style churn with no
+#   bug-finding value in a reference implementation.
+# - llvm-prefer-static-over-anonymous-namespace, misc-use-internal-linkage:
+#   conflict with Google style, which prefers anonymous namespaces.
+# - readability-function-cognitive-complexity: fires only on test bodies.
+# - clang-analyzer-cplusplus.Move: duplicates bugprone-use-after-move but
+#   reports inside the generated callee rather than at the call site, so it
+#   cannot be suppressed where tests deliberately exercise moved-from objects.
+# - cppcoreguidelines-pro-bounds-avoid-unchecked-container-access: added in
+#   clang-tidy 22; fires on every operator[] in tests.
 Checks: '
     *,
     -abseil-*,
@@ -38,7 +58,18 @@ Checks: '
     -*-braces-around-statements,
     -*-named-parameter,
     -*-uppercase-literal-suffix,
-    -misc-no-recursion
+    -misc-no-recursion,
+    -cppcoreguidelines-avoid-magic-numbers,
+    -readability-convert-member-functions-to-static,
+    -google-explicit-constructor,
+    -hicpp-explicit-conversions,
+    -misc-const-correctness,
+    -modernize-use-nodiscard,
+    -llvm-prefer-static-over-anonymous-namespace,
+    -misc-use-internal-linkage,
+    -readability-function-cognitive-complexity,
+    -clang-analyzer-cplusplus.Move,
+    -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access
 '
 CheckOptions:
     - key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals
@@ -46,5 +77,7 @@ CheckOptions:
     - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
       value: true
 WarningsAsErrors: ''
-HeaderFilterRegex: '^(?!.*_deps).*'
+# Exclude third-party dependencies fetched by CMake and headers generated from
+# scripts/protocol.j2; findings in generated code should be fixed in the template.
+HeaderFilterRegex: '^(?!.*(_deps|/generated/)).*'
 FormatStyle: file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,14 +108,18 @@ target_sources(
 if(XYZ_PROTOCOL_IS_NOT_SUBPROJECT)
 
   if(${BUILD_TESTING})
+    # SYSTEM marks the dependencies' include directories as system headers so
+    # that clang-tidy and compiler warnings do not report on third-party code.
     FetchContent_Declare(
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG v1.15.2)
+      GIT_TAG v1.15.2
+      SYSTEM)
     FetchContent_Declare(
       google_benchmark
       GIT_REPOSITORY https://github.com/google/benchmark.git
-      GIT_TAG v1.9.1)
+      GIT_TAG v1.9.1
+      SYSTEM)
     # For Windows: Prevent overriding the parent project's compiler/linker
     # settings
     set(gtest_force_shared_crt


### PR DESCRIPTION
Step 1 of #39 (see the plan and checklist there). Configuration only, no source changes.

- Mark `googletest` and `google_benchmark` as `SYSTEM` in `FetchContent_Declare` so third-party headers are excluded regardless of `HeaderFilterRegex`.
- Extend `HeaderFilterRegex` to exclude `/generated/`; findings in generated code should be fixed in `scripts/protocol.j2`.
- Disable checks that contradict the design or are pure style noise, with rationale recorded in `.clang-tidy`:
  - `cppcoreguidelines-avoid-magic-numbers` (alias of the already-disabled `readability-magic-numbers`)
  - `readability-convert-member-functions-to-static` (interface structs and conforming types must have non-static members)
  - `google-explicit-constructor`, `hicpp-explicit-conversions` (implicit construction of `protocol` from a conforming type is by design)
  - `misc-const-correctness`, `modernize-use-nodiscard`
  - `llvm-prefer-static-over-anonymous-namespace`, `misc-use-internal-linkage` (conflict with Google style)
  - `readability-function-cognitive-complexity` (fires only on test bodies)
  - `clang-analyzer-cplusplus.Move` (duplicates `bugprone-use-after-move` but reports inside the generated callee, so it cannot be `NOLINT`ed at the test site)
  - `cppcoreguidelines-pro-bounds-avoid-unchecked-container-access` (new in clang-tidy 22; fires on every `operator[]` in tests)

## Verification

- `clang-tidy --verify-config` passes (the pre-existing `cert-dcl21-cpp` entry is unknown to clang-tidy 22 only; CI runs 21).
- Warnings on `main` drop from ~386 to ~100 measured locally with clang-tidy 22. Everything remaining is either a deliberate moved-from-object test or a genuine finding; both are step 2 of #39.
- `./scripts/cmake.sh --debug -DCLANG_TIDY_ENABLE=1`: builds, 87/87 tests pass.
- pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHjiPBayDu7hLZyhcQK3tt
