### PR TITLE
Move CI static analysis and sanitizers to LLVM 22 and add an opt-in clang-tidy pre-commit hook

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -27,7 +27,10 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
-  COMPILER_VERSION: 21
+  # Keep in sync with the clang-tidy package in docker/Dockerfile and the
+  # expected version in cmake/modules/FindClangTidy.cmake, so that local runs
+  # and CI use the same check set.
+  COMPILER_VERSION: 22
   UV_FROZEN: 1
 
 jobs:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -180,6 +180,32 @@ jobs:
               lib: "libc++21",
             }
           - {
+              name: "Ubuntu Clang-22 + libc++",
+              os: ubuntu-24.04,
+              compiler:
+                {
+                  type: CLANG,
+                  version: 22,
+                  cc: "clang-22",
+                  cxx: "clang++-22",
+                  std: 20,
+                },
+              lib: "libc++22",
+            }
+          - {
+              name: "Ubuntu Clang-22 (C++23) + libc++",
+              os: ubuntu-24.04,
+              compiler:
+                {
+                  type: CLANG,
+                  version: 22,
+                  cc: "clang-22",
+                  cxx: "clang++-22",
+                  std: 23,
+                },
+              lib: "libc++22",
+            }
+          - {
               name: "Visual Studio 2019",
               os: windows-latest,
               compiler: { type: VISUAL, version: 16, cc: "cl", cxx: "cl" },

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -146,7 +146,7 @@ jobs:
               compiler:
                 {
                   type: CLANG,
-                  version: 19,
+                  version: 20,
                   cc: "clang-20",
                   cxx: "clang++-20",
                   std: 20,

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -27,7 +27,8 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
-  COMPILER_VERSION: 21
+  # include-what-you-use is built from its clang_<COMPILER_VERSION> branch.
+  COMPILER_VERSION: 22
   UV_FROZEN: 1
 
 jobs:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         sanitizer: ["asan", "tsan", "msan"]
-        clang_version: ["19"]
+        clang_version: ["22"]
     steps:
       - uses: actions/checkout@v5
       - uses: lukka/get-cmake@v4.4.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,19 @@ repos:
   rev: v0.8.0
   hooks:
   - id: action-validator
+- repo: local
+  hooks:
+  # Runs the same full clang-tidy build as the "Clang Tidy" CI workflow, so
+  # local and CI findings match. It is a full build, so it is opt-in (manual
+  # stage) rather than run on every commit:
+  #
+  #   uv run pre-commit run --hook-stage manual clang-tidy
+  #
+  # Requires clang-tidy 22 on PATH (installed in the devcontainer).
+  - id: clang-tidy
+    name: clang-tidy
+    entry: ./scripts/cmake.sh --debug --clang-tidy
+    language: system
+    pass_filenames: false
+    files: '(\.(cc|h|j2)|CMakeLists\.txt|\.clang-tidy)$|^cmake/'
+    stages: [manual]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,9 @@ if(XYZ_PROTOCOL_IS_NOT_SUBPROJECT)
     FetchContent_Declare(
       google_benchmark
       GIT_REPOSITORY https://github.com/google/benchmark.git
-      GIT_TAG v1.9.1
+      # v1.9.5 or later is required for Clang 22, which warns that __COUNTER__
+      # is a C2y extension; benchmark's own -Werror build failed on it before.
+      GIT_TAG v1.9.5
       SYSTEM)
     # For Windows: Prevent overriding the parent project's compiler/linker
     # settings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,25 @@ The script will configure, build, and execute tests.
 
 CI runs clang-tidy on every translation unit and fails on any finding
 (`WarningsAsErrors: '*'` in `.clang-tidy`). To reproduce locally, with
-`clang-tidy` on your `PATH` (it is installed in the devcontainer):
+`clang-tidy` on your `PATH` (the devcontainer installs `clang-tidy-22`):
 
 ```bash
 ./scripts/cmake.sh --debug --clang-tidy
 ```
+
+The same run is available as an opt-in pre-commit hook. It is a full build, so
+it is not part of the default commit-time hooks:
+
+```bash
+uv run pre-commit run --hook-stage manual clang-tidy
+```
+
+CI pins clang-tidy 22 (`COMPILER_VERSION` in `.github/workflows/clang-tidy.yml`);
+the check set differs between releases, so a different local version may
+report different findings. CMake warns at configure time when the version it
+found does not match. The pinned version is recorded in three places that must
+be updated together: the workflow, `docker/Dockerfile`, and
+`ClangTidy_EXPECTED_MAJOR_VERSION` in `cmake/modules/FindClangTidy.cmake`.
 
 Fix genuine findings. Suppress false positives at the site with a `NOLINT`
 comment that names the check and gives a reason, or, for a check that does not

--- a/cmake/modules/FindClangTidy.cmake
+++ b/cmake/modules/FindClangTidy.cmake
@@ -24,8 +24,15 @@ option(CLANG_TIDY_ENABLE "Build with support for clang-tidy" OFF)
 
 set(ClangTidy_VERBOSITY_LEVEL 3 CACHE STRING "Clang Tidy verbosity level (the higher the level, the more output)")
 
+# The major version that CI runs (COMPILER_VERSION in
+# .github/workflows/clang-tidy.yml) and that docker/Dockerfile installs. The
+# check set differs between clang-tidy releases, so a different local version
+# may report findings that CI does not, or miss findings that CI reports.
+set(ClangTidy_EXPECTED_MAJOR_VERSION 22 CACHE STRING "clang-tidy major version used by CI")
+
+# Prefer the versioned binary matching CI when several are installed.
 find_program(ClangTidy_EXECUTABLE
-    NAMES clang-tidy
+    NAMES clang-tidy-${ClangTidy_EXPECTED_MAJOR_VERSION} clang-tidy
 )
 
 macro(_clang_tidy_log)
@@ -90,6 +97,14 @@ if(ClangTidy_EXECUTABLE)
     mark_as_advanced(ClangTidy_EXECUTABLE)
     get_clang_tidy_version(EXECUTABLE ${ClangTidy_EXECUTABLE} RESULT ClangTidy_VERSION)
     _clang_tidy_log("clang-tidy version ${ClangTidy_VERSION}")
+    string(REGEX REPLACE "\\..*" "" ClangTidy_MAJOR_VERSION "${ClangTidy_VERSION}")
+    if(CLANG_TIDY_ENABLE AND NOT ClangTidy_MAJOR_VERSION STREQUAL ClangTidy_EXPECTED_MAJOR_VERSION)
+        message(WARNING
+            "clang-tidy ${ClangTidy_VERSION} found at ${ClangTidy_EXECUTABLE}, but CI "
+            "runs clang-tidy ${ClangTidy_EXPECTED_MAJOR_VERSION}; findings may differ. "
+            "Install clang-tidy-${ClangTidy_EXPECTED_MAJOR_VERSION} or set "
+            "-DClangTidy_EXECUTABLE=<path>.")
+    endif()
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:26.04
 
 # Install base tools and C++ development tools.
+#
+# clang-tidy is pinned to the same major version as the "Clang Tidy" CI
+# workflow (COMPILER_VERSION in .github/workflows/clang-tidy.yml) so that a
+# local `./scripts/cmake.sh --clang-tidy` run reports the same findings as CI.
+# The unversioned `clang-tidy` package on this Ubuntu release is LLVM 21.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang-tidy \
+    clang-tidy-22 \
     cmake \
     curl \
     g++ \
@@ -20,7 +25,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ssh \
     unzip \
     wget \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/clang-tidy-22 /usr/local/bin/clang-tidy
 
 # Install bazelisk.
 RUN ARCH=$(dpkg --print-architecture) && \


### PR DESCRIPTION
## Summary

- Move the clang-tidy pin from LLVM 21 to 22 in every place it lives: the `Clang Tidy` and `IWYU` workflows, `docker/Dockerfile` (`clang-tidy-22` + `clang-tidy` symlink), and `cmake/modules/FindClangTidy.cmake` (prefers `clang-tidy-22`, warns on a major-version mismatch with CI).
- Add Clang-22 (C++20 and C++23) entries to the `cmake.yml` build matrix, and fix the Clang-20 entry, which asked `setup-clang` for version 19 and only worked because the runner image already ships clang-20.
- Bump google benchmark v1.9.1 → v1.9.5. Clang 22 warns that `__COUNTER__` is a C2y extension (`-Wc2y-extensions`), and benchmark compiles its own sources with `-Werror -pedantic-errors`, so v1.9.1 failed to build in the new Clang-22 jobs. v1.9.5 suppresses the warning around its `__COUNTER__` probe.
- Add a manual-stage pre-commit hook `clang-tidy` that runs `./scripts/cmake.sh --debug --clang-tidy`, invoked with `uv run pre-commit run --hook-stage manual clang-tidy`. It is skipped by the default `pre-commit run --all-files`, so the `pre-commit` CI job is unaffected.
- Run the sanitizer jobs (asan+ubsan, tsan, msan) with Clang 22 instead of 19.
- Document the above in `CONTRIBUTING.md`.

## Why

`.clang-tidy` already disables `cppcoreguidelines-pro-bounds-avoid-unchecked-container-access`, which only exists in clang-tidy 22, and clang-format is pinned to 22, while CI analysed with 21. clang-tidy silently ignores unknown check names, so nothing broke, but local and CI runs used different check sets.

## Test plan

- [x] `uv run pre-commit validate-config` and `uv run pre-commit run --all-files` pass; the `clang-tidy` hook is not run at the default stage.
- [x] `uv run pre-commit run --hook-stage manual clang-tidy` runs the full build.
- [x] `FindClangTidy.cmake` version warning verified with a stub `clang-tidy` reporting 21.1.6.
- [x] Local `./scripts/cmake.sh --debug --clean` with benchmark v1.9.5: 87/87 tests pass.
- [x] `Clang Tidy` workflow passes on LLVM 22 with zero new findings.
- [x] `IWYU` workflow builds from the `clang_22` branch and passes.
- [x] New Clang-22 matrix jobs pass (they failed on v1.9.1 before the benchmark bump).
- [x] Clang-20 matrix jobs pass with Clang 20 actually installed.
- [x] Sanitizer jobs (asan+ubsan, tsan, msan) pass on Clang 22.
- [x] `docker/Dockerfile` change verified in a rebuilt Codespace: `clang-tidy` resolves to `clang-tidy-22` (LLVM 22.1.2), CMake selects it with no version warning, the manual hook passes on a clean build, and an injected in-tree finding is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHjiPBayDu7hLZyhcQK3tt