### PR TITLE
Make clang-tidy a required status check for merging to main

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,16 +13,14 @@ on:
       - "CMakePresets.json"
       - "cmake/**"
       - "**/*.j2"
+  # No `paths:` filter here. The `clang-tidy` job is a required status check
+  # for merging to main, and a workflow that is filtered out by `paths:` never
+  # reports a check, which leaves unrelated pull requests blocked as
+  # "Expected - Waiting for status to be reported". Instead, the
+  # `detect-changes` job below decides whether the build needs to run, and a
+  # job skipped by an `if:` condition counts as a passing check.
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/clang-tidy.yml" # This file
-      - "**/*.cc"
-      - "**/*.h"
-      - "**/CMakeLists.txt"
-      - "CMakePresets.json"
-      - "cmake/**"
-      - "**/*.j2"
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -34,7 +32,38 @@ env:
   UV_FROZEN: 1
 
 jobs:
+  detect-changes:
+    # Only pull requests need change detection; pushes to main and scheduled
+    # runs always run clang-tidy.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Keep in sync with the `push.paths` list above.
+          filters: |
+            relevant:
+              - ".github/workflows/clang-tidy.yml" # This file
+              - "**/*.cc"
+              - "**/*.h"
+              - "**/CMakeLists.txt"
+              - "CMakePresets.json"
+              - "cmake/**"
+              - "**/*.j2"
+
   clang-tidy:
+    needs: detect-changes
+    # Run unless change detection positively reported that nothing relevant
+    # changed. `!cancelled()` lets this job run when `detect-changes` was
+    # skipped (push and schedule events), and an empty output (because
+    # `detect-changes` failed) falls through to running the build rather than
+    # silently passing the required check.
+    if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
     runs-on: ubuntu-latest
 
     # reviewdog posts review comments on pull requests and check annotations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,10 @@ The script will configure, build, and execute tests.
 ### Static Analysis
 
 CI runs clang-tidy on every translation unit and fails on any finding
-(`WarningsAsErrors: '*'` in `.clang-tidy`). To reproduce locally, with
+(`WarningsAsErrors: '*'` in `.clang-tidy`). The `clang-tidy` job is a required
+status check for merging to `main`; on pull requests that touch no C++, CMake,
+or template sources the job is skipped, which counts as passing. To reproduce
+locally, with
 `clang-tidy` on your `PATH` (the devcontainer installs `clang-tidy-22`):
 
 ```bash


### PR DESCRIPTION
Refs #185.

Workflow-side preparation for making the `clang-tidy` job a required status check on `main`.

- Drop the `paths:` filter from the `pull_request` trigger of `.github/workflows/clang-tidy.yml`. A workflow filtered out by `paths:` never reports a check, so once the check is required, PRs that touch no C++ (e.g. `DRAFT.md`-only changes) would sit blocked as "Expected — Waiting for status to be reported".
- Add a `detect-changes` job (`dorny/paths-filter@v3`, same glob list as the `push` trigger) that gates the `clang-tidy` job. A job skipped by an `if:` condition counts as a passing check. If change detection fails, the build runs rather than silently passing.
- `push` and `schedule` triggers are unchanged.
- `CONTRIBUTING.md` documents the required check.

**Merge this before enabling the required check** in the `main` ruleset (needs admin; instructions in #185), otherwise the next non-C++ PR is stuck.

Verification: `uv run pre-commit run --files .github/workflows/clang-tidy.yml CONTRIBUTING.md` passes (including `action-validator`). The `Clang Tidy` run on this PR exercises the new `detect-changes` → `clang-tidy` path.

https://claude.ai/code/session_01TGTHbSozmsGbTecSZkuPSt
