### PR TITLE
Add XYZ_CONSTEVAL_CHECK for readable consteval assertion failures

### DIFF
--- a/reflection/CMakeLists.txt
+++ b/reflection/CMakeLists.txt
@@ -14,7 +14,8 @@ xyz_add_test(
   xyz_protocol::reflection_protocol
   FILES
   protocol_test.cc
-  allocator_tests.cc)
+  allocator_tests.cc
+  consteval_check_test.cc)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(reflection_protocol_test PRIVATE -freflection)

--- a/reflection/consteval_check.h
+++ b/reflection/consteval_check.h
@@ -142,11 +142,11 @@ struct value_capturer {
 };
 
 constexpr void report(check_result result, std::string_view expression_text,
-                       std::source_location location) {
+                      std::source_location location) {
   if (result.passed) return;
   std::string message = std::string(location.file_name()) + ":" +
-                         to_display_string(location.line()) +
-                         ": check failed: " + std::string(expression_text);
+                        to_display_string(location.line()) +
+                        ": check failed: " + std::string(expression_text);
   if (!result.expansion.empty()) {
     message += " [" + result.expansion + "]";
   }
@@ -157,23 +157,30 @@ constexpr void report(check_result result, std::string_view expression_text,
 // applied to the captured value.
 template <typename Lhs>
 constexpr void report(captured_value<Lhs> value,
-                       std::string_view expression_text,
-                       std::source_location location) {
+                      std::string_view expression_text,
+                      std::source_location location) {
   report(value.evaluate(), expression_text, location);
 }
 
 }  // namespace detail::consteval_check
 }  // namespace xyz
 
-#define XYZ_CONSTEVAL_CHECK(...)                                          \
-  do {                                                                    \
-    _Pragma("GCC diagnostic push")                                        \
-        _Pragma("GCC diagnostic ignored \"-Wparentheses\"")               \
-            ::xyz::detail::consteval_check::report(                       \
-                (::xyz::detail::consteval_check::value_capturer{} <=      \
-                 __VA_ARGS__),                                            \
-                #__VA_ARGS__, std::source_location::current());           \
-    _Pragma("GCC diagnostic pop")                                         \
+// GCC's -Wparentheses fires on `capturer <= lhs == rhs`, so the capture is
+// bracketed by push/pop pragmas. Kept as separate macros so that the main
+// macro below stays readable after clang-format.
+#define XYZ_CONSTEVAL_CHECK_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
+  _Pragma("GCC diagnostic push")                                   \
+      _Pragma("GCC diagnostic ignored \"-Wparentheses\"")
+#define XYZ_CONSTEVAL_CHECK_INTERNAL_RESTORE_WARNINGS \
+  _Pragma("GCC diagnostic pop")
+
+#define XYZ_CONSTEVAL_CHECK(...)                                           \
+  do {                                                                     \
+    XYZ_CONSTEVAL_CHECK_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS             \
+    ::xyz::detail::consteval_check::report(                                \
+        (::xyz::detail::consteval_check::value_capturer{} <= __VA_ARGS__), \
+        #__VA_ARGS__, std::source_location::current());                    \
+    XYZ_CONSTEVAL_CHECK_INTERNAL_RESTORE_WARNINGS                          \
   } while (false)
 
 #endif  // XYZ_REFLECTION_CONSTEVAL_CHECK_H_

--- a/reflection/consteval_check.h
+++ b/reflection/consteval_check.h
@@ -1,0 +1,179 @@
+/* Copyright (c) 2025 The XYZ Protocol Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+#ifndef XYZ_REFLECTION_CONSTEVAL_CHECK_H_
+#define XYZ_REFLECTION_CONSTEVAL_CHECK_H_
+
+// A compile-time assertion helper for use inside `consteval` blocks and
+// functions. `static_assert` requires its operand to be a constant expression
+// on its own, which locals in a consteval block are not; a bare `throw` works
+// but the diagnostic only shows the hand-written message. XYZ_CONSTEVAL_CHECK
+// decomposes `lhs OP rhs`, and on failure throws consteval_check_failure whose
+// what() reports "<file>:<line>: check failed: <expression> [<lhs> OP <rhs>]".
+// GCC prints what() of an uncaught exception during constant evaluation.
+// Everything is constexpr, so the macro also works at run time, which is how
+// consteval_check_test.cc inspects the thrown message.
+
+#include <charconv>
+#include <concepts>
+#include <exception>
+#include <source_location>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#if __has_include(<meta>)
+#include <meta>
+#endif
+
+namespace xyz {
+
+class consteval_check_failure : public std::exception {
+ public:
+  constexpr explicit consteval_check_failure(std::string message)
+      : message_(std::move(message)) {}
+
+  constexpr const char* what() const noexcept override {
+    return message_.c_str();
+  }
+
+ private:
+  std::string message_;
+};
+
+namespace detail::consteval_check {
+
+// Best-effort rendering of an operand for the diagnostic.
+template <typename T>
+constexpr std::string to_display_string(const T& value) {
+  if constexpr (std::is_same_v<T, bool>) {
+    return value ? "true" : "false";
+  } else if constexpr (std::is_integral_v<T>) {
+    char buffer[32];
+    auto result = std::to_chars(buffer, buffer + sizeof(buffer), value);
+    return std::string(buffer, result.ptr);
+  } else if constexpr (std::is_convertible_v<T, std::string_view>) {
+    return "\"" + std::string(std::string_view(value)) + "\"";
+#if __has_include(<meta>)
+  } else if constexpr (std::is_same_v<T, std::meta::info>) {
+    return std::meta::display_string_of(value);
+#endif
+  } else {
+    return "{?}";
+  }
+}
+
+struct check_result {
+  bool passed;
+  std::string expansion;  // e.g. "\"y\" == \"x\"", or "" for a unary check.
+};
+
+template <typename Lhs>
+struct captured_value {
+  Lhs value;  // Lhs may be a reference type; captured by forwarding reference.
+
+  template <typename Rhs>
+  friend constexpr check_result operator==(captured_value&& lhs, Rhs&& rhs) {
+    return {static_cast<bool>(lhs.value == rhs),
+            to_display_string(lhs.value) + " == " + to_display_string(rhs)};
+  }
+
+  template <typename Rhs>
+  friend constexpr check_result operator!=(captured_value&& lhs, Rhs&& rhs) {
+    return {static_cast<bool>(lhs.value != rhs),
+            to_display_string(lhs.value) + " != " + to_display_string(rhs)};
+  }
+
+  template <typename Rhs>
+  friend constexpr check_result operator<(captured_value&& lhs, Rhs&& rhs) {
+    return {static_cast<bool>(lhs.value < rhs),
+            to_display_string(lhs.value) + " < " + to_display_string(rhs)};
+  }
+
+  template <typename Rhs>
+  friend constexpr check_result operator>(captured_value&& lhs, Rhs&& rhs) {
+    return {static_cast<bool>(lhs.value > rhs),
+            to_display_string(lhs.value) + " > " + to_display_string(rhs)};
+  }
+
+  template <typename Rhs>
+  friend constexpr check_result operator<=(captured_value&& lhs, Rhs&& rhs) {
+    return {static_cast<bool>(lhs.value <= rhs),
+            to_display_string(lhs.value) + " <= " + to_display_string(rhs)};
+  }
+
+  template <typename Rhs>
+  friend constexpr check_result operator>=(captured_value&& lhs, Rhs&& rhs) {
+    return {static_cast<bool>(lhs.value >= rhs),
+            to_display_string(lhs.value) + " >= " + to_display_string(rhs)};
+  }
+
+  // Unary use (XYZ_CONSTEVAL_CHECK(some_bool)): no comparison operator is
+  // ever applied, so `report` calls this directly instead.
+  constexpr check_result evaluate() const
+    requires std::convertible_to<Lhs, bool>
+  {
+    return {static_cast<bool>(value), ""};
+  }
+};
+
+struct value_capturer {
+  template <typename T>
+  constexpr captured_value<T&&> operator<=(T&& lhs) const {
+    return captured_value<T&&>{std::forward<T>(lhs)};
+  }
+};
+
+constexpr void report(check_result result, std::string_view expression_text,
+                       std::source_location location) {
+  if (result.passed) return;
+  std::string message = std::string(location.file_name()) + ":" +
+                         to_display_string(location.line()) +
+                         ": check failed: " + std::string(expression_text);
+  if (!result.expansion.empty()) {
+    message += " [" + result.expansion + "]";
+  }
+  throw consteval_check_failure(std::move(message));
+}
+
+// Overload for the unary case, where no comparison operator was ever
+// applied to the captured value.
+template <typename Lhs>
+constexpr void report(captured_value<Lhs> value,
+                       std::string_view expression_text,
+                       std::source_location location) {
+  report(value.evaluate(), expression_text, location);
+}
+
+}  // namespace detail::consteval_check
+}  // namespace xyz
+
+#define XYZ_CONSTEVAL_CHECK(...)                                          \
+  do {                                                                    \
+    _Pragma("GCC diagnostic push")                                        \
+        _Pragma("GCC diagnostic ignored \"-Wparentheses\"")               \
+            ::xyz::detail::consteval_check::report(                       \
+                (::xyz::detail::consteval_check::value_capturer{} <=      \
+                 __VA_ARGS__),                                            \
+                #__VA_ARGS__, std::source_location::current());           \
+    _Pragma("GCC diagnostic pop")                                         \
+  } while (false)
+
+#endif  // XYZ_REFLECTION_CONSTEVAL_CHECK_H_

--- a/reflection/consteval_check_test.cc
+++ b/reflection/consteval_check_test.cc
@@ -1,0 +1,148 @@
+/* Copyright (c) 2025 The XYZ Protocol Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+
+#include "consteval_check.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+
+using xyz::consteval_check_failure;
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Compile-time usage.
+// ---------------------------------------------------------------------------
+
+TEST(ConstevalCheckTest, PassingChecksInConstevalBlock) {
+  // Every comparison operator, an arithmetic left-hand side, a string_view
+  // comparison, and a unary bool check, all evaluated during constant
+  // evaluation. Compiling this test is the assertion: a failing check would
+  // throw during the `consteval` block and fail to compile.
+  consteval {
+    int a = 5;
+    int b = 15;
+    std::string_view name = "hello";
+    bool ready = true;
+
+    XYZ_CONSTEVAL_CHECK(a + b == 20);
+    XYZ_CONSTEVAL_CHECK(a != b);
+    XYZ_CONSTEVAL_CHECK(a < b);
+    XYZ_CONSTEVAL_CHECK(b > a);
+    XYZ_CONSTEVAL_CHECK(a <= 5);
+    XYZ_CONSTEVAL_CHECK(b >= 15);
+    XYZ_CONSTEVAL_CHECK(name == "hello");
+    XYZ_CONSTEVAL_CHECK(ready);
+  }
+}
+
+consteval bool ConstevalCheckFailureIsCatchable() {
+  try {
+    XYZ_CONSTEVAL_CHECK(10 < 5);
+    return false;
+  } catch (const consteval_check_failure&) {
+    return true;
+  }
+}
+
+TEST(ConstevalCheckTest, FailureIsCatchableAtCompileTime) {
+  static_assert(ConstevalCheckFailureIsCatchable());
+}
+
+// ---------------------------------------------------------------------------
+// Run-time usage: `XYZ_CONSTEVAL_CHECK` is plain constexpr code, so it also
+// works at run time, which lets these tests inspect the thrown message.
+// ---------------------------------------------------------------------------
+
+TEST(ConstevalCheckTest, MessageContainsLocationExpressionAndExpansion) {
+  {
+    int value = 5;
+    try {
+      XYZ_CONSTEVAL_CHECK(value + 10 == 21);
+      FAIL() << "expected consteval_check_failure to be thrown";
+    } catch (const consteval_check_failure& failure) {
+      std::string_view what = failure.what();
+      EXPECT_NE(what.find("consteval_check_test.cc:"), std::string_view::npos);
+      EXPECT_NE(what.find("check failed: value + 10 == 21"),
+                std::string_view::npos);
+      EXPECT_NE(what.find("[15 == 21]"), std::string_view::npos);
+    }
+  }
+
+  {
+    std::string_view actual = "y";
+    try {
+      XYZ_CONSTEVAL_CHECK(actual == "x");
+      FAIL() << "expected consteval_check_failure to be thrown";
+    } catch (const consteval_check_failure& failure) {
+      std::string_view what = failure.what();
+      EXPECT_NE(what.find("[\"y\" == \"x\"]"), std::string_view::npos);
+    }
+  }
+
+  {
+    bool left = true;
+    bool right = false;
+    try {
+      XYZ_CONSTEVAL_CHECK(left == right);
+      FAIL() << "expected consteval_check_failure to be thrown";
+    } catch (const consteval_check_failure& failure) {
+      std::string_view what = failure.what();
+      EXPECT_NE(what.find("[true == false]"), std::string_view::npos);
+    }
+  }
+
+  {
+    bool ready = false;
+    try {
+      XYZ_CONSTEVAL_CHECK(ready);
+      FAIL() << "expected consteval_check_failure to be thrown";
+    } catch (const consteval_check_failure& failure) {
+      std::string_view what = failure.what();
+      EXPECT_EQ(what.find('['), std::string_view::npos);
+    }
+  }
+}
+
+// A type with no display support: not bool, not integral, not convertible to
+// std::string_view, and (outside a reflection context) not std::meta::info.
+struct Opaque {
+  int tag;
+
+  constexpr bool operator==(const Opaque& other) const {
+    return tag == other.tag;
+  }
+};
+
+TEST(ConstevalCheckTest, UnsupportedTypeDisplaysPlaceholder) {
+  Opaque left{.tag = 1};
+  Opaque right{.tag = 2};
+  try {
+    XYZ_CONSTEVAL_CHECK(left == right);
+    FAIL() << "expected consteval_check_failure to be thrown";
+  } catch (const consteval_check_failure& failure) {
+    std::string_view what = failure.what();
+    EXPECT_NE(what.find("{?}"), std::string_view::npos);
+  }
+}
+
+}  // namespace

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -29,6 +29,8 @@ if(XYZ_PROTOCOL_BUILD_REFLECTION)
         reflection_tutorial
         VERSION
         26
+        LINK_LIBRARIES
+        xyz_protocol::reflection_protocol
         FILES
         reflection.cc)
     target_compile_options(reflection_tutorial PRIVATE -freflection)

--- a/tutorials/reflection.cc
+++ b/tutorials/reflection.cc
@@ -25,10 +25,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <meta>
 #include <optional>
 #include <ranges>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
+
+#include "consteval_check.h"
 
 // A very brief (and intentionally incomplete) tour of C++26 reflection.
 
@@ -80,21 +81,25 @@ TEST(TutorialsReflection, MetaInfoQueries) {
 TEST(TutorialsReflection, MembersOfWithConstevalBlock) {
   // `nonstatic_data_members_of` inspects a class's members.
 
-  // We use `throw` inside a `consteval` block rather than `static_assert`
+  // We use a check inside a `consteval` block rather than `static_assert`
   // or `EXPECT_*`: `static_assert` needs `members` to independently be a
   // constant expression, and `EXPECT_*`'s comparison helpers aren't
   // `constexpr` functions.
   // The body of a `consteval` block runs at compile time.
 
+  // A bare `throw std::runtime_error("...")` would work too, but the
+  // resulting diagnostic only shows the hand-written string, not what was
+  // actually compared. `XYZ_CONSTEVAL_CHECK` decomposes the expression and
+  // throws `xyz::consteval_check_failure`, whose `what()` carries the
+  // `file:line`, the expression text, and the operand values, e.g.
+  // "reflection.cc:NN: check failed: identifier_of(members[1]) == \"y\"
+  // [\"x\" == \"y\"]". GCC prints `what()` of an uncaught exception thrown
+  // during constant evaluation as part of the compile error.
   consteval {
     auto members = nonstatic_data_members_of(
         ^^Point, std::meta::access_context::current());
-    if (identifier_of(members[0]) != "x") {
-      throw std::runtime_error("members[0] is not \"x\"");
-    }
-    if (identifier_of(members[1]) != "y") {
-      throw std::runtime_error("members[1] is not \"y\"");
-    }
+    XYZ_CONSTEVAL_CHECK(identifier_of(members[0]) == "x");
+    XYZ_CONSTEVAL_CHECK(identifier_of(members[1]) == "y");
   }
 }
 


### PR DESCRIPTION
Closes #167.

## Summary

`tutorials/reflection.cc` asserted inside a `consteval` block with a bare `throw std::runtime_error("...")`, so a failure only reported the hand-written string. Following @hanickadot's suggestion in #167, this adds `reflection/consteval_check.h`, a Catch2-style expression decomposer:

```cpp
XYZ_CONSTEVAL_CHECK(identifier_of(members[1]) == "y");
```

On failure it throws `xyz::consteval_check_failure` whose `what()` carries `file:line`, the expression text and the operand values. GCC prints that as part of the compile error:

```
tutorials/reflection.cc:103:3: error: uncaught exception of type 'xyz::consteval_check_failure';
'what()': '.../tutorials/reflection.cc:102: check failed: identifier_of(members[1]) == "x" ["y" == "x"]'
```

## Design notes

- `<=` capture (Catch2 style) rather than `->*` so an arithmetic left-hand side (`a + b == 20`) decomposes without extra parentheses. GCC's `-Wparentheses` fires on `x <= y == z`, and the test targets build with `-Werror -Wall`, so the macro wraps the expression in `_Pragma("GCC diagnostic ignored \"-Wparentheses\"")`.
- Operands render via `std::to_chars` (integers), quoting (anything convertible to `string_view`), `display_string_of` (`std::meta::info`), or `{?}` otherwise — `std::to_string`/`std::format` are not constexpr.
- Everything is constexpr, so the helper also works at run time; `reflection/consteval_check_test.cc` uses that to inspect the message, plus a compile-time `try`/`catch` test.
- Only the `XYZ_PROTOCOL_BUILD_REFLECTION` targets (GCC 16, C++26, `-freflection`) compile any of this; the rest of the CI compiler matrix is unaffected.

## Verification

- `CXX=g++-16 CC=gcc-16 ./scripts/cmake.sh --debug --reflection`: 153/153 tests pass, warning-free.
- `uv run pre-commit run --all-files`: clean.
- Deliberately broke a tutorial check to capture the diagnostic above, then reverted.
