### PR TITLE
Retarget the C++26 reflection build from gcc-16 to a GCC trunk snapshot

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,6 +31,7 @@ jobs:
   build:
     name: ${{ matrix.settings.name }} ${{ matrix.configuration }}
     runs-on: ${{ matrix.settings.os }}
+    continue-on-error: ${{ matrix.settings.informational || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -238,7 +239,26 @@ jobs:
                 },
             }
           - {
-              name: "Ubuntu GCC-16 (C++26 Reflection)",
+              name: "Ubuntu GCC trunk (C++26 Reflection)",
+              os: ubuntu-26.04,
+              compiler:
+                {
+                  type: GCC_TRUNK,
+                  version: trunk,
+                  cc: "/opt/gcc-latest/bin/gcc",
+                  cxx: "/opt/gcc-latest/bin/g++",
+                  std: 26,
+                },
+              reflection: true,
+            }
+          # Ubuntu 26.04's gcc-16 is a frozen experimental snapshot whose
+          # reflection support no longer receives fixes (issue #122). It is kept
+          # here as a non-blocking, informational job because it is what a stock
+          # Ubuntu 26.04 user gets from `apt install gcc-16`; the GCC trunk job
+          # above is the gating one. Drop this entry once the reflection backend
+          # needs fixes that only exist on trunk.
+          - {
+              name: "Ubuntu GCC-16 (C++26 Reflection, informational)",
               os: ubuntu-26.04,
               compiler:
                 {
@@ -248,6 +268,8 @@ jobs:
                   cxx: "g++-16",
                   std: 26,
                 },
+              reflection: true,
+              informational: true,
             }
     steps:
       - uses: actions/checkout@v5
@@ -269,14 +291,29 @@ jobs:
         with:
           version: ${{ matrix.settings.compiler.version }}
           platform: x64
+      - name: Install GCC trunk
+        if: matrix.settings.compiler.type == 'GCC_TRUNK'
+        # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
+        # scripts/cmake.py finds /opt/gcc-latest itself, so no PATH changes are needed.
+        # The unversioned URL tracks upstream weekly. If a snapshot regression breaks
+        # this job, temporarily pin the versioned file linked from that page, e.g.
+        # https://kayari.org/gcc-latest/gcc-latest_17.0.0-20260816git8df013222dff.deb
+        run: |
+          wget --quiet https://kayari.org/gcc-latest/gcc-latest.deb
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ./gcc-latest.deb
       - name: Install GCC 16
         if: matrix.settings.compiler.type == 'GCC16'
+        # Set CXX/CC explicitly so scripts/cmake.py does not pick a stray
+        # /opt/gcc-latest on the runner.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends gcc-16 g++-16
+          echo "CXX=${{ matrix.settings.compiler.cxx }}" >> "$GITHUB_ENV"
+          echo "CC=${{ matrix.settings.compiler.cc }}" >> "$GITHUB_ENV"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Set up Python
         run: uv sync
       - name: Run CMake
-        run: ./scripts/cmake.sh --${{ matrix.configuration == 'Debug' && 'debug' || 'release' }} ${{ matrix.settings.compiler.type == 'GCC16' && '--reflection' || '' }}
+        run: ./scripts/cmake.sh --${{ matrix.configuration == 'Debug' && 'debug' || 'release' }} ${{ matrix.settings.reflection && '--reflection' || '' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ option(ENABLE_MSAN "Enable Memory Sanitizer" OFF)
 option(
   XYZ_PROTOCOL_BUILD_REFLECTION
   "Also build and test tutorials/reflection.cc, which requires a compiler \
-with C++26 P2996 reflection support (eg. GCC 16+ with -freflection)."
+with C++26 P2996 reflection support (eg. a GCC trunk snapshot with -freflection)."
   OFF)
 
 if(XYZ_PROTOCOL_BUILD_REFLECTION)
@@ -55,6 +55,23 @@ if(XYZ_PROTOCOL_BUILD_REFLECTION)
         "XYZ_PROTOCOL_BUILD_REFLECTION is ON but the compiler "
         "(${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}) does not "
         "support C++26 reflection.")
+  endif()
+
+  # A non-distro GCC (e.g. the gcc-latest trunk snapshot installed to
+  # /opt/gcc-latest, see docker/Dockerfile) keeps its libstdc++ in a
+  # directory ld.so does not search by default. Embed that directory as a
+  # build rpath so test executables linked against it run without needing
+  # LD_LIBRARY_PATH set.
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    execute_process(
+      COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libstdc++.so
+      OUTPUT_VARIABLE XYZ_PROTOCOL_LIBSTDCXX_PATH
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    get_filename_component(XYZ_PROTOCOL_LIBSTDCXX_PATH
+                            "${XYZ_PROTOCOL_LIBSTDCXX_PATH}" REALPATH)
+    get_filename_component(XYZ_PROTOCOL_LIBSTDCXX_DIRECTORY
+                            "${XYZ_PROTOCOL_LIBSTDCXX_PATH}" DIRECTORY)
+    list(APPEND CMAKE_BUILD_RPATH "${XYZ_PROTOCOL_LIBSTDCXX_DIRECTORY}")
   endif()
 endif()
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,25 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && ln -s /usr/bin/clang-tidy-22 /usr/local/bin/clang-tidy
 
+# Install a GCC trunk snapshot for the C++26 reflection backend, from
+# https://jwakely.github.io/pkg-gcc-latest/. Ubuntu's gcc-16 package (installed
+# above) is a frozen experimental snapshot whose reflection support no longer
+# receives fixes (issue #122), so we prefer this continuously-updated trunk
+# build when available. It is x86_64 only, so other architectures fall back to
+# gcc-16. It installs to /opt/gcc-latest; scripts/cmake.py locates it there
+# explicitly, and CMakeLists.txt adds a build rpath so linked executables can
+# find its libstdc++ at runtime without any PATH or LD_LIBRARY_PATH changes.
+RUN ARCH=$(dpkg --print-architecture) && \
+    case "$ARCH" in \
+        amd64) \
+            wget -nv https://kayari.org/gcc-latest/gcc-latest.deb -O /tmp/gcc-latest.deb \
+            && apt-get update && apt-get install -y --no-install-recommends /tmp/gcc-latest.deb \
+            && rm -f /tmp/gcc-latest.deb \
+            && rm -rf /var/lib/apt/lists/* \
+            ;; \
+        *) echo "gcc-latest is x86_64-only; the reflection build will fall back to gcc-16 on $ARCH" ;; \
+    esac
+
 # Install bazelisk.
 RUN ARCH=$(dpkg --print-architecture) && \
     wget https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-linux-${ARCH} -O /usr/local/bin/bazelisk \

--- a/scripts/agentic-sandbox.py
+++ b/scripts/agentic-sandbox.py
@@ -160,7 +160,7 @@ def main() -> None:
     log(f"Note: Your current directory {project_root} is mounted to /workspace")
 
     if args.agent is None:
-        print("To build and test with the C++26 reflection backend (GCC 16):")
+        print("To build and test with the C++26 reflection backend (GCC trunk):")
         print("  ./scripts/cmake.sh --release --reflection -B build-reflection")
         container_cmd = None
     else:

--- a/scripts/cmake.py
+++ b/scripts/cmake.py
@@ -6,6 +6,11 @@ import os
 import subprocess
 from typing import Any
 
+# Directory of the GCC trunk snapshot published at
+# https://jwakely.github.io/pkg-gcc-latest/, used as the default C++26
+# reflection compiler when present (see --reflection below).
+GCC_LATEST_BIN_DIRECTORY = "/opt/gcc-latest/bin"
+
 
 def main() -> None:
     """Execute the CMake build and test process based on command-line arguments."""
@@ -42,7 +47,9 @@ def main() -> None:
         "--reflection",
         action="store_true",
         help="Build and test tutorials/reflection.cc (requires a P2996 "
-        "reflection compiler, e.g. CXX=g++-16 CC=gcc-16)",
+        "reflection compiler; defaults to the GCC trunk snapshot in "
+        "/opt/gcc-latest if present, else g++-16/gcc-16; set CXX/CC in the "
+        "environment to override)",
     )
     parser.add_argument(
         "--clang-tidy",
@@ -100,11 +107,20 @@ def main() -> None:
     # A P2996 reflection compiler is required to configure with
     # XYZ_PROTOCOL_BUILD_REFLECTION=ON. CMake only reads CXX/CC
     # from the environment, not from -D cache variables, so set them here
-    # rather than as configure_args.
+    # rather than as configure_args. An existing CXX in the environment is
+    # left untouched so callers can override the compiler; otherwise prefer
+    # the GCC trunk snapshot in /opt/gcc-latest (see docker/Dockerfile) and
+    # fall back to Ubuntu's gcc-16 package if that snapshot isn't installed.
     configure_env = os.environ.copy()
-    if args.reflection:
-        configure_env["CXX"] = "g++-16"
-        configure_env["CC"] = "gcc-16"
+    if args.reflection and "CXX" not in configure_env:
+        gcc_latest_cxx = os.path.join(GCC_LATEST_BIN_DIRECTORY, "g++")
+        gcc_latest_cc = os.path.join(GCC_LATEST_BIN_DIRECTORY, "gcc")
+        if os.path.exists(gcc_latest_cxx):
+            configure_env["CXX"] = gcc_latest_cxx
+            configure_env["CC"] = gcc_latest_cc
+        else:
+            configure_env["CXX"] = "g++-16"
+            configure_env["CC"] = "gcc-16"
 
     log(f"Running: {' '.join(configure_args)}")
     subprocess.check_call(configure_args, env=configure_env)


### PR DESCRIPTION
Fixes #122.

Ubuntu 26.04's `gcc-16` is a frozen experimental snapshot whose reflection support no longer receives fixes (e.g. `can_substitute(^^S, {^^int&()})` fails on gcc-16 and passes on trunk). This retargets the C++26 reflection build to Jonathan Wakely's prebuilt GCC trunk package (https://jwakely.github.io/pkg-gcc-latest/, currently GCC 17.0.0-20260816).

## Changes

- **`docker/Dockerfile`** — on amd64, installs `gcc-latest.deb` to `/opt/gcc-latest`. The package is x86_64-only, so arm64 keeps `gcc-16` as the fallback. `gcc-16` stays installed on all architectures.
- **`scripts/cmake.py`** — `--reflection` prefers `/opt/gcc-latest/bin/g++` when present, else `g++-16`; an existing `CXX`/`CC` in the environment overrides both.
- **`CMakeLists.txt`** — with reflection on, embeds the compiler's `libstdc++` directory (from `g++ -print-file-name=libstdc++.so`) as a build rpath, so executables linked against the snapshot's `/opt/gcc-latest/lib64` run without `LD_LIBRARY_PATH`.
- **`.github/workflows/cmake.yml`** — the reflection job now builds with GCC trunk and is the gating one. `gcc-16` is kept as a **non-blocking, informational** job (`continue-on-error`) because it is what a stock Ubuntu 26.04 user gets from `apt install gcc-16`; drop it once the backend needs trunk-only fixes. A comment notes how to temporarily pin a versioned snapshot if trunk regresses.
- `scripts/agentic-sandbox.py` — hint text.

## Verification (local, Ubuntu 26.04 devcontainer, `.deb` extracted with `dpkg-deb -x`)

- `CXX=…/gcc-latest/bin/g++ ./scripts/cmake.sh --release --reflection`: compiler identified as GNU 17.0.0, **162/162 tests pass** (including `reflection_protocol_test` and `reflection_tutorial`); `readelf -d` shows `RUNPATH` pointing at the snapshot's `lib64` and `ldd` resolves its `libstdc++.so.6`.
- `./scripts/cmake.sh --release --reflection` with no override (no `/opt/gcc-latest`): falls back to GNU 16.0.1, 162/162 pass.
- Trunk still requires `-freflection`, so the existing flags are unchanged.
- pre-commit (yaml, dockerfilelint, ruff, action-validator) and `pytest scripts` pass.

## Verification (after devcontainer rebuild, 2026-08-28)

- The Dockerfile layer installs correctly: `/opt/gcc-latest/bin/g++` reports GCC 17.0.0 20260816, and `./scripts/cmake.sh --release --reflection` now picks it up with no `CXX` override — GNU 17.0.0, 162/162 tests pass.
- All 47 CI checks pass, including both gating "Ubuntu GCC trunk (C++26 Reflection)" jobs (exercising the runner-side `.deb` install) and the two informational GCC-16 jobs.

## Notes

- The unversioned `.deb` URL tracks upstream weekly, so the image and the trunk CI job are intentionally unpinned.

