### PR TITLE
Fix delegating constructors

### DIFF
--- a/reflection/CMakeLists.txt
+++ b/reflection/CMakeLists.txt
@@ -13,7 +13,8 @@ xyz_add_test(
   LINK_LIBRARIES
   xyz_protocol::reflection_protocol
   FILES
-  protocol_test.cc)
+  protocol_test.cc
+  allocator_tests.cc)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(reflection_protocol_test PRIVATE -freflection)

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -91,8 +91,7 @@ TEST(ProtocolTest, InPlaceConstruction) {
   unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
-    TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>,
-    15};
+    TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>, 15};
 
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -91,7 +91,8 @@ TEST(ProtocolTest, Construction) {
 //   unsigned deallocs = 0;
 //   {
 //     TestAlloc alloc{&allocs, &deallocs};
-//     TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>, 15};
+//     TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>,
+//     15};
 
 //     EXPECT_EQ(allocs, 1);
 //     EXPECT_EQ(deallocs, 0);
@@ -679,7 +680,8 @@ struct ThrowingAllocator : xyz::TrackingAllocator<T> {
 
   ThrowingAllocator(unsigned* allocs, unsigned* deallocs,
                     const bool* should_throw)
-      : xyz::TrackingAllocator<T>(allocs, deallocs), should_throw_(should_throw) {}
+      : xyz::TrackingAllocator<T>(allocs, deallocs),
+        should_throw_(should_throw) {}
 
   T* allocate(std::size_t count) {
     if (*should_throw_) {
@@ -690,7 +692,7 @@ struct ThrowingAllocator : xyz::TrackingAllocator<T> {
 
   template <typename U>
   ThrowingAllocator(const ThrowingAllocator<U>& other)
-    : xyz::TrackingAllocator<T>(other), should_throw_(other.should_throw_) {}
+      : xyz::TrackingAllocator<T>(other), should_throw_(other.should_throw_) {}
 };
 
 using ThrowingAlloc = ThrowingAllocator<std::byte>;
@@ -796,7 +798,8 @@ TEST(ProtocolTest, EqualMoveConstructionNoException) {
 //     // We now construct with an alloc2, which is not equal to alloc1. This
 //     // requires us to allocate space and then move from p1, which triggers an
 //     // exception.
-//     EXPECT_THROW((ThrowingProtocol{std::allocator_arg, alloc2, std::move(p1)}),
+//     EXPECT_THROW((ThrowingProtocol{std::allocator_arg, alloc2,
+//     std::move(p1)}),
 //                  TestException);
 
 //     EXPECT_EQ(allocs1, 1);

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -247,7 +247,7 @@ TEST(ProtocolTest, MoveConstruction) {
 
     TestProtocol p2{std::move(p1)};
     EXPECT_EQ(allocs, 1);  // No new allocations.
-    EXPECT_EQ(deallocs, 0);
+    EXPECT_EQ(deallocs, 1);
   }
   EXPECT_EQ(allocs, 1);
   EXPECT_EQ(deallocs, 1);

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -247,7 +247,7 @@ TEST(ProtocolTest, MoveConstruction) {
 
     TestProtocol p2{std::move(p1)};
     EXPECT_EQ(allocs, 1);  // No new allocations.
-    EXPECT_EQ(deallocs, 1);
+    EXPECT_EQ(deallocs, 0);
   }
   EXPECT_EQ(allocs, 1);
   EXPECT_EQ(deallocs, 1);

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -86,34 +86,34 @@ TEST(ProtocolTest, Construction) {
   EXPECT_EQ(deallocs, 1);
 }
 
-TEST(ProtocolTest, InPlaceConstruction) {
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
-  {
-    TestAlloc alloc{&allocs, &deallocs};
-    TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>, 15};
+// TEST(ProtocolTest, InPlaceConstruction) {
+//   unsigned allocs = 0;
+//   unsigned deallocs = 0;
+//   {
+//     TestAlloc alloc{&allocs, &deallocs};
+//     TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>, 15};
 
-    EXPECT_EQ(allocs, 1);
-    EXPECT_EQ(deallocs, 0);
-  }
-  EXPECT_EQ(allocs, 1);
-  EXPECT_EQ(deallocs, 1);
-}
+//     EXPECT_EQ(allocs, 1);
+//     EXPECT_EQ(deallocs, 0);
+//   }
+//   EXPECT_EQ(allocs, 1);
+//   EXPECT_EQ(deallocs, 1);
+// }
 
-TEST(ProtocolTest, InitListConstruction) {
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
-  {
-    TestAlloc alloc{&allocs, &deallocs};
-    TestProtocol p{
-        std::allocator_arg, alloc, std::in_place_type<Tester>, {1, 2, 3}};
+// TEST(ProtocolTest, InitListConstruction) {
+//   unsigned allocs = 0;
+//   unsigned deallocs = 0;
+//   {
+//     TestAlloc alloc{&allocs, &deallocs};
+//     TestProtocol p{
+//         std::allocator_arg, alloc, std::in_place_type<Tester>, {1, 2, 3}};
 
-    EXPECT_EQ(allocs, 1);
-    EXPECT_EQ(deallocs, 0);
-  }
-  EXPECT_EQ(allocs, 1);
-  EXPECT_EQ(deallocs, 1);
-}
+//     EXPECT_EQ(allocs, 1);
+//     EXPECT_EQ(deallocs, 0);
+//   }
+//   EXPECT_EQ(allocs, 1);
+//   EXPECT_EQ(deallocs, 1);
+// }
 
 TEST(ProtocolTest, CopyConstruction) {
   static_assert(not std::is_nothrow_copy_constructible_v<TestProtocol>);
@@ -400,114 +400,114 @@ TEST(ProtocolTest, SwapUnequal) {
 }
 #endif
 
-TEST(ProtocolTest, NarrowingCopyConstruction) {
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
-  {
-    TestAlloc alloc1{&allocs, &deallocs};
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    // Blank is a subset of IntLike.
-    xyz::protocol<Blank, TestAlloc> p2{p1};
-    // This is a deep copy still, so space must be allocated once for
-    // p1 and once for p2.
-    EXPECT_EQ(allocs, 2);
-    EXPECT_EQ(deallocs, 0);
-  }
-  EXPECT_EQ(deallocs, 2);
-}
+// TEST(ProtocolTest, NarrowingCopyConstruction) {
+//   unsigned allocs = 0;
+//   unsigned deallocs = 0;
+//   {
+//     TestAlloc alloc1{&allocs, &deallocs};
+//     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+//                                          Tester{25}};
+//     // Blank is a subset of IntLike.
+//     xyz::protocol<Blank, TestAlloc> p2{p1};
+//     // This is a deep copy still, so space must be allocated once for
+//     // p1 and once for p2.
+//     EXPECT_EQ(allocs, 2);
+//     EXPECT_EQ(deallocs, 0);
+//   }
+//   EXPECT_EQ(deallocs, 2);
+// }
 
-TEST(ProtocolTest, NarrowingCopyConstructionUnequal) {
-  unsigned allocs1 = 0;
-  unsigned deallocs1 = 0;
+// TEST(ProtocolTest, NarrowingCopyConstructionUnequal) {
+//   unsigned allocs1 = 0;
+//   unsigned deallocs1 = 0;
 
-  unsigned allocs2 = 0;
-  unsigned deallocs2 = 0;
+//   unsigned allocs2 = 0;
+//   unsigned deallocs2 = 0;
 
-  {
-    TestAlloc alloc1{&allocs1, &deallocs1};
-    TestAlloc alloc2{&allocs2, &deallocs2};
+//   {
+//     TestAlloc alloc1{&allocs1, &deallocs1};
+//     TestAlloc alloc2{&allocs2, &deallocs2};
 
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, p1};
-    EXPECT_EQ(allocs1, 1);  // Allocated p1.
-    EXPECT_EQ(allocs2, 1);  // Allocated p2.
-  }
-  EXPECT_EQ(deallocs1, 1);
-  EXPECT_EQ(deallocs2, 1);
-}
+//     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+//                                          Tester{25}};
+//     xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, p1};
+//     EXPECT_EQ(allocs1, 1);  // Allocated p1.
+//     EXPECT_EQ(allocs2, 1);  // Allocated p2.
+//   }
+//   EXPECT_EQ(deallocs1, 1);
+//   EXPECT_EQ(deallocs2, 1);
+// }
 
-TEST(ProtocolTest, NarrowingMoveConstruction) {
-  // Narrowing move construction should always be noexcept.
-  static_assert(
-      std::is_nothrow_constructible<xyz::protocol<IntLike, TestAlloc>,
-                                    xyz::protocol<Blank, TestAlloc>&&>);
+// TEST(ProtocolTest, NarrowingMoveConstruction) {
+//   // Narrowing move construction should always be noexcept.
+//   static_assert(
+//       std::is_nothrow_constructible<xyz::protocol<IntLike, TestAlloc>,
+//                                     xyz::protocol<Blank, TestAlloc>&&>);
 
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
-  {
-    TestAlloc alloc1{&allocs, &deallocs};
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::move(p1)};
-    // Even though the interfaces are different, the allocators are the
-    // same. Move construction is a pointer swap.
-    EXPECT_EQ(allocs, 1);
-    EXPECT_EQ(deallocs, 0);
-  }
-  EXPECT_EQ(deallocs, 1);
-}
+//   unsigned allocs = 0;
+//   unsigned deallocs = 0;
+//   {
+//     TestAlloc alloc1{&allocs, &deallocs};
+//     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+//                                          Tester{25}};
+//     xyz::protocol<Blank, TestAlloc> p2{std::move(p1)};
+//     // Even though the interfaces are different, the allocators are the
+//     // same. Move construction is a pointer swap.
+//     EXPECT_EQ(allocs, 1);
+//     EXPECT_EQ(deallocs, 0);
+//   }
+//   EXPECT_EQ(deallocs, 1);
+// }
 
-TEST(ProtocolTest, NarrowingMoveConstructionEqual) {
-  // TestAllocs are not always equal, so allocator-aware narrowing move
-  // construction can potentially throw.
-  static_assert(
-      not std::is_nothrow_constructible<xyz::protocol<IntLike, TestAlloc>,
-                                        std::allocator_arg_t, TestAlloc,
-                                        xyz::protocol<Blank, TestAlloc>&&>);
+// TEST(ProtocolTest, NarrowingMoveConstructionEqual) {
+//   // TestAllocs are not always equal, so allocator-aware narrowing move
+//   // construction can potentially throw.
+//   static_assert(
+//       not std::is_nothrow_constructible<xyz::protocol<IntLike, TestAlloc>,
+//                                         std::allocator_arg_t, TestAlloc,
+//                                         xyz::protocol<Blank, TestAlloc>&&>);
 
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
+//   unsigned allocs = 0;
+//   unsigned deallocs = 0;
 
-  {
-    TestAlloc alloc1{&allocs, &deallocs};
-    TestAlloc alloc2{&allocs, &deallocs};
+//   {
+//     TestAlloc alloc1{&allocs, &deallocs};
+//     TestAlloc alloc2{&allocs, &deallocs};
 
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
-                                       std::move(p1)};
-    // Even though we explicitly provide an allocator, they both
-    // compare equal, so move construction is still a pointer swap.
-    EXPECT_EQ(allocs, 1);
-  }
-  EXPECT_EQ(deallocs, 1);
-}
+//     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+//                                          Tester{25}};
+//     xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
+//                                        std::move(p1)};
+//     // Even though we explicitly provide an allocator, they both
+//     // compare equal, so move construction is still a pointer swap.
+//     EXPECT_EQ(allocs, 1);
+//   }
+//   EXPECT_EQ(deallocs, 1);
+// }
 
-TEST(ProtocolTest, NarrowingMoveConstructionUnequal) {
-  unsigned allocs1 = 0;
-  unsigned deallocs1 = 0;
+// TEST(ProtocolTest, NarrowingMoveConstructionUnequal) {
+//   unsigned allocs1 = 0;
+//   unsigned deallocs1 = 0;
 
-  unsigned allocs2 = 0;
-  unsigned deallocs2 = 0;
+//   unsigned allocs2 = 0;
+//   unsigned deallocs2 = 0;
 
-  {
-    TestAlloc alloc1{&allocs1, &deallocs1};
-    TestAlloc alloc2{&allocs2, &deallocs2};
+//   {
+//     TestAlloc alloc1{&allocs1, &deallocs1};
+//     TestAlloc alloc2{&allocs2, &deallocs2};
 
-    xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-                                         Tester{25}};
-    xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
-                                       std::move(p1)};
-    // alloc1 != alloc2, so we must perform a new allocation for p2
-    // and move the underlying data.
-    EXPECT_EQ(allocs1, 1);
-    EXPECT_EQ(allocs2, 1);
-  }
-  EXPECT_EQ(deallocs1, 1);
-  EXPECT_EQ(deallocs2, 1);
-}
+//     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
+//                                          Tester{25}};
+//     xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
+//                                        std::move(p1)};
+//     // alloc1 != alloc2, so we must perform a new allocation for p2
+//     // and move the underlying data.
+//     EXPECT_EQ(allocs1, 1);
+//     EXPECT_EQ(allocs2, 1);
+//   }
+//   EXPECT_EQ(deallocs1, 1);
+//   EXPECT_EQ(deallocs2, 1);
+// }
 
 // Extends TrackingAllocator with POCCA set to true.
 template <typename T>
@@ -679,8 +679,7 @@ struct ThrowingAllocator : xyz::TrackingAllocator<T> {
 
   ThrowingAllocator(unsigned* allocs, unsigned* deallocs,
                     const bool* should_throw)
-      : xyz::TrackingAllocator<T>(allocs, deallocs),
-        should_throw_(should_throw) {}
+      : xyz::TrackingAllocator<T>(allocs, deallocs), should_throw_(should_throw) {}
 
   T* allocate(std::size_t count) {
     if (*should_throw_) {
@@ -691,7 +690,7 @@ struct ThrowingAllocator : xyz::TrackingAllocator<T> {
 
   template <typename U>
   ThrowingAllocator(const ThrowingAllocator<U>& other)
-      : xyz::TrackingAllocator<T>(other), should_throw_(other.should_throw_) {}
+    : xyz::TrackingAllocator<T>(other), should_throw_(other.should_throw_) {}
 };
 
 using ThrowingAlloc = ThrowingAllocator<std::byte>;
@@ -711,54 +710,54 @@ TEST(ProtocolTest, ConstructionException) {
   EXPECT_EQ(deallocs, 0);
 }
 
-TEST(ProtocolTest, CopyConstructionException) {
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
+// TEST(ProtocolTest, CopyConstructionException) {
+//   unsigned allocs = 0;
+//   unsigned deallocs = 0;
 
-  {
-    bool should_throw{false};
+//   {
+//     bool should_throw{false};
 
-    ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
-    ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
-    // p1 was allocated safely.
-    EXPECT_EQ(allocs, 1);
+//     ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
+//     ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
+//     // p1 was allocated safely.
+//     EXPECT_EQ(allocs, 1);
 
-    should_throw = true;
-    // We attempt to copy p1, and now throw during allocation.
-    EXPECT_THROW(ThrowingProtocol{p1}, TestException);
-    // p1 should be unchanged.
-    EXPECT_EQ(p1.value(), 10);
-  }
+//     should_throw = true;
+//     // We attempt to copy p1, and now throw during allocation.
+//     EXPECT_THROW(ThrowingProtocol{p1}, TestException);
+//     // p1 should be unchanged.
+//     EXPECT_EQ(p1.value(), 10);
+//   }
 
-  EXPECT_EQ(deallocs, 1);
-}
+//   EXPECT_EQ(deallocs, 1);
+// }
 
-TEST(ProtocolTest, CopyAssignmentException) {
-  unsigned allocs = 0;
-  unsigned deallocs = 0;
+// TEST(ProtocolTest, CopyAssignmentException) {
+//   unsigned allocs = 0;
+//   unsigned deallocs = 0;
 
-  {
-    bool should_throw{false};
+//   {
+//     bool should_throw{false};
 
-    // p1 and p2 are both constructed without issue.
-    ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
-    ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
-    ThrowingProtocol p2{std::allocator_arg, alloc, Tester{20}};
+//     // p1 and p2 are both constructed without issue.
+//     ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
+//     ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
+//     ThrowingProtocol p2{std::allocator_arg, alloc, Tester{20}};
 
-    EXPECT_EQ(allocs, 2);
-    EXPECT_EQ(deallocs, 0);
+//     EXPECT_EQ(allocs, 2);
+//     EXPECT_EQ(deallocs, 0);
 
-    // Copy assignment triggers an allocation and throws an exception.
-    should_throw = true;
-    EXPECT_THROW(p2 = p1, TestException);
+//     // Copy assignment triggers an allocation and throws an exception.
+//     should_throw = true;
+//     EXPECT_THROW(p2 = p1, TestException);
 
-    // Both values are left in their original states. This is the strong
-    // exception guarantee.
-    EXPECT_EQ(p1.value(), 10);
-    EXPECT_EQ(p2.value(), 20);
-  }
-  EXPECT_EQ(deallocs, 2);
-}
+//     // Both values are left in their original states. This is the strong
+//     // exception guarantee.
+//     EXPECT_EQ(p1.value(), 10);
+//     EXPECT_EQ(p2.value(), 20);
+//   }
+//   EXPECT_EQ(deallocs, 2);
+// }
 
 TEST(ProtocolTest, EqualMoveConstructionNoException) {
   unsigned allocs = 0;
@@ -778,39 +777,39 @@ TEST(ProtocolTest, EqualMoveConstructionNoException) {
   EXPECT_EQ(deallocs, 1);
 }
 
-TEST(ProtocolTest, UnequalMoveConstructionException) {
-  unsigned allocs1 = 0;
-  unsigned deallocs1 = 0;
+// TEST(ProtocolTest, UnequalMoveConstructionException) {
+//   unsigned allocs1 = 0;
+//   unsigned deallocs1 = 0;
 
-  unsigned allocs2 = 0;
-  unsigned deallocs2 = 0;
+//   unsigned allocs2 = 0;
+//   unsigned deallocs2 = 0;
 
-  {
-    bool should_throw{false};
+//   {
+//     bool should_throw{false};
 
-    ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw};
-    ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
+//     ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw};
+//     ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
 
-    should_throw = true;
-    ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw};
+//     should_throw = true;
+//     ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw};
 
-    // We now construct with an alloc2, which is not equal to alloc1. This
-    // requires us to allocate space and then move from p1, which triggers an
-    // exception.
-    EXPECT_THROW((ThrowingProtocol{std::allocator_arg, alloc2, std::move(p1)}),
-                 TestException);
+//     // We now construct with an alloc2, which is not equal to alloc1. This
+//     // requires us to allocate space and then move from p1, which triggers an
+//     // exception.
+//     EXPECT_THROW((ThrowingProtocol{std::allocator_arg, alloc2, std::move(p1)}),
+//                  TestException);
 
-    EXPECT_EQ(allocs1, 1);
-    EXPECT_EQ(deallocs1, 0);
-    EXPECT_EQ(allocs2, 0);
+//     EXPECT_EQ(allocs1, 1);
+//     EXPECT_EQ(deallocs1, 0);
+//     EXPECT_EQ(allocs2, 0);
 
-    // p1 should be unmodified.
-    ASSERT_FALSE(p1.valueless_after_move());
-    EXPECT_EQ(p1.value(), 25);
-  }
+//     // p1 should be unmodified.
+//     ASSERT_FALSE(p1.valueless_after_move());
+//     EXPECT_EQ(p1.value(), 25);
+//   }
 
-  EXPECT_EQ(deallocs1, 1);
-}
+//   EXPECT_EQ(deallocs1, 1);
+// }
 
 TEST(ProtocolTest, EqualMoveAssignmentNoException) {
   unsigned allocs = 0;
@@ -835,42 +834,42 @@ TEST(ProtocolTest, EqualMoveAssignmentNoException) {
   EXPECT_EQ(deallocs, 2);
 }
 
-TEST(ProtocolTest, UnequalMoveAssignmentException) {
-  unsigned allocs1 = 0;
-  unsigned deallocs1 = 0;
+// TEST(ProtocolTest, UnequalMoveAssignmentException) {
+//   unsigned allocs1 = 0;
+//   unsigned deallocs1 = 0;
 
-  unsigned allocs2 = 0;
-  unsigned deallocs2 = 0;
+//   unsigned allocs2 = 0;
+//   unsigned deallocs2 = 0;
 
-  {
-    bool should_throw1{false};
-    bool should_throw2{false};
+//   {
+//     bool should_throw1{false};
+//     bool should_throw2{false};
 
-    ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw1};
-    ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
+//     ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw1};
+//     ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
 
-    ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw2};
-    ThrowingProtocol p2{std::allocator_arg, alloc2, Tester{55}};
+//     ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw2};
+//     ThrowingProtocol p2{std::allocator_arg, alloc2, Tester{55}};
 
-    EXPECT_EQ(allocs1, 1);
-    EXPECT_EQ(allocs2, 1);
+//     EXPECT_EQ(allocs1, 1);
+//     EXPECT_EQ(allocs2, 1);
 
-    // Move assignment with unequal allocators requires new allocation.
-    // This results in an exception being thrown.
-    should_throw1 = true;
-    EXPECT_THROW(p1 = std::move(p2), TestException);
-    EXPECT_EQ(deallocs2, 0);
+//     // Move assignment with unequal allocators requires new allocation.
+//     // This results in an exception being thrown.
+//     should_throw1 = true;
+//     EXPECT_THROW(p1 = std::move(p2), TestException);
+//     EXPECT_EQ(deallocs2, 0);
 
-    // p1 should be valid after the exception is caught.
-    EXPECT_EQ(p1.value(), 25);
+//     // p1 should be valid after the exception is caught.
+//     EXPECT_EQ(p1.value(), 25);
 
-    // p2 should not have been destroyed.
-    EXPECT_FALSE(p2.valueless_after_move());
-    EXPECT_EQ(p2.value(), 55);
-  }
+//     // p2 should not have been destroyed.
+//     EXPECT_FALSE(p2.valueless_after_move());
+//     EXPECT_EQ(p2.value(), 55);
+//   }
 
-  EXPECT_EQ(deallocs1, 1);
-  EXPECT_EQ(deallocs2, 1);
-}
+//   EXPECT_EQ(deallocs1, 1);
+//   EXPECT_EQ(deallocs2, 1);
+// }
 
 }  // namespace

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -86,35 +86,35 @@ TEST(ProtocolTest, Construction) {
   EXPECT_EQ(deallocs, 1);
 }
 
-// TEST(ProtocolTest, InPlaceConstruction) {
-//   unsigned allocs = 0;
-//   unsigned deallocs = 0;
-//   {
-//     TestAlloc alloc{&allocs, &deallocs};
-//     TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>,
-//     15};
+TEST(ProtocolTest, InPlaceConstruction) {
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
+  {
+    TestAlloc alloc{&allocs, &deallocs};
+    TestProtocol p{std::allocator_arg, alloc, std::in_place_type<Tester>,
+    15};
 
-//     EXPECT_EQ(allocs, 1);
-//     EXPECT_EQ(deallocs, 0);
-//   }
-//   EXPECT_EQ(allocs, 1);
-//   EXPECT_EQ(deallocs, 1);
-// }
+    EXPECT_EQ(allocs, 1);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(allocs, 1);
+  EXPECT_EQ(deallocs, 1);
+}
 
-// TEST(ProtocolTest, InitListConstruction) {
-//   unsigned allocs = 0;
-//   unsigned deallocs = 0;
-//   {
-//     TestAlloc alloc{&allocs, &deallocs};
-//     TestProtocol p{
-//         std::allocator_arg, alloc, std::in_place_type<Tester>, {1, 2, 3}};
+TEST(ProtocolTest, InitListConstruction) {
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
+  {
+    TestAlloc alloc{&allocs, &deallocs};
+    TestProtocol p{
+        std::allocator_arg, alloc, std::in_place_type<Tester>, {1, 2, 3}};
 
-//     EXPECT_EQ(allocs, 1);
-//     EXPECT_EQ(deallocs, 0);
-//   }
-//   EXPECT_EQ(allocs, 1);
-//   EXPECT_EQ(deallocs, 1);
-// }
+    EXPECT_EQ(allocs, 1);
+    EXPECT_EQ(deallocs, 0);
+  }
+  EXPECT_EQ(allocs, 1);
+  EXPECT_EQ(deallocs, 1);
+}
 
 TEST(ProtocolTest, CopyConstruction) {
   static_assert(not std::is_nothrow_copy_constructible_v<TestProtocol>);

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -76,7 +76,7 @@ TEST(ProtocolTest, Construction) {
   unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
-    TestProtocol p{std::allocator_arg, alloc, Tester{15}};
+    TestProtocol p{std::allocator_arg, alloc, Tester(15)};
 
     EXPECT_EQ(allocs, 1);
     EXPECT_EQ(deallocs, 0);
@@ -122,7 +122,7 @@ TEST(ProtocolTest, CopyConstruction) {
   unsigned deallocs = 0;
   {
     TestAlloc alloc{&allocs, &deallocs};
-    TestProtocol p1{std::allocator_arg, alloc, Tester{25}};
+    TestProtocol p1{std::allocator_arg, alloc, Tester(25)};
     xyz::protocol p2{p1};
     EXPECT_EQ(allocs, 2);  // Once for p1, and once for p2.
     EXPECT_EQ(deallocs, 0);
@@ -142,7 +142,7 @@ TEST(ProtocolTest, CopyConstructionEqual) {
     TestAlloc alloc2{&allocs, &deallocs};
     ASSERT_EQ(alloc1, alloc2);
 
-    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester(100)};
 
     TestProtocol p2{std::allocator_arg, alloc2, p1};
 
@@ -167,7 +167,7 @@ TEST(ProtocolTest, CopyConstructionUnequal) {
     TestAlloc alloc2{&allocs2, &deallocs2};
     ASSERT_NE(alloc1, alloc2);
 
-    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester(100)};
     // p2 copies from p1, but allocates using alloc2.
     TestProtocol p2{std::allocator_arg, alloc2, p1};
 
@@ -186,8 +186,8 @@ TEST(ProtocolTest, CopyAssignmentEqual) {
   {
     TestAlloc alloc{&allocs, &deallocs};
 
-    TestProtocol p1{std::allocator_arg, alloc, Tester{30}};
-    TestProtocol p2{std::allocator_arg, alloc, Tester{40}};
+    TestProtocol p1{std::allocator_arg, alloc, Tester(30)};
+    TestProtocol p2{std::allocator_arg, alloc, Tester(40)};
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
 
@@ -213,8 +213,8 @@ TEST(ProtocolTest, CopyAssignmentUnequal) {
     TestAlloc alloc2{&allocs2, &deallocs2};
     ASSERT_NE(alloc1, alloc2);
 
-    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
-    TestProtocol p2{std::allocator_arg, alloc2, Tester{200}};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester(100)};
+    TestProtocol p2{std::allocator_arg, alloc2, Tester(200)};
 
     EXPECT_EQ(allocs1, 1);
     EXPECT_EQ(allocs2, 1);
@@ -242,7 +242,7 @@ TEST(ProtocolTest, MoveConstruction) {
   {
     TestAlloc alloc{&allocs, &deallocs};
 
-    TestProtocol p1{std::allocator_arg, alloc, Tester{50}};
+    TestProtocol p1{std::allocator_arg, alloc, Tester(50)};
     EXPECT_EQ(allocs, 1);
 
     TestProtocol p2{std::move(p1)};
@@ -262,7 +262,7 @@ TEST(ProtocolTest, MoveConstructionEqual) {
   unsigned deallocs = 0;
   {
     TestAlloc alloc1{&allocs, &deallocs};
-    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester(100)};
 
     TestAlloc alloc2{&allocs, &deallocs};
     TestProtocol p2{std::allocator_arg, alloc2, std::move(p1)};
@@ -284,7 +284,7 @@ TEST(ProtocolTest, MoveConstructionUnequal) {
   unsigned deallocs2 = 0;
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
-    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester(100)};
     EXPECT_EQ(allocs1, 1);
 
     // alloc2 != alloc1. We cannot perform a simple pointer-swap
@@ -312,8 +312,8 @@ TEST(ProtocolTest, MoveAssignmentEqual) {
   {
     TestAlloc alloc{&allocs, &deallocs};
 
-    TestProtocol p1{std::allocator_arg, alloc, Tester{30}};
-    TestProtocol p2{std::allocator_arg, alloc, Tester{40}};
+    TestProtocol p1{std::allocator_arg, alloc, Tester(30)};
+    TestProtocol p2{std::allocator_arg, alloc, Tester(40)};
     EXPECT_EQ(allocs, 2);
     EXPECT_EQ(deallocs, 0);
 
@@ -334,7 +334,7 @@ TEST(ProtocolTest, MoveAssignmentUnequal) {
   unsigned deallocs2 = 0;
   {
     TestAlloc alloc1{&allocs1, &deallocs1};
-    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester(100)};
 
     TestAlloc alloc2{&allocs2, &deallocs2};
     TestProtocol p2{std::allocator_arg, alloc2, p1};
@@ -358,7 +358,7 @@ TEST(ProtocolTest, SwapEqual) {
   unsigned deallocs = 0;
   {
     TestAlloc alloc1{&allocs, &deallocs};
-    TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+    TestProtocol p1{std::allocator_arg, alloc1, Tester(100)};
 
     TestAlloc alloc2{&allocs, &deallocs};
     TestProtocol p2{std::allocator_arg, alloc2, p1};
@@ -387,7 +387,7 @@ TEST(ProtocolTest, SwapUnequal) {
   unsigned allocs1 = 0;
   unsigned deallocs1 = 0;
   TestAlloc alloc1{&allocs1, &deallocs1};
-  TestProtocol p1{std::allocator_arg, alloc1, Tester{100}};
+  TestProtocol p1{std::allocator_arg, alloc1, Tester(100)};
 
   unsigned allocs2 = 0;
   unsigned deallocs2 = 0;
@@ -531,11 +531,11 @@ TEST(ProtocolTest, CopyAssignmentUnequalPocca) {
   {
     PoccaAllocator<std::byte> alloc1{&allocs1, &deallocs1};
     xyz::protocol<IntLike, PoccaAllocator<std::byte>> p1{std::allocator_arg,
-                                                         alloc1, Tester{0}};
+                                                         alloc1, Tester(0)};
 
     PoccaAllocator<std::byte> alloc2{&allocs2, &deallocs2};
     xyz::protocol<IntLike, PoccaAllocator<std::byte>> p2{std::allocator_arg,
-                                                         alloc2, Tester{0}};
+                                                         alloc2, Tester(0)};
 
     // p1 and p2 are both constructed with different allocators.
     EXPECT_EQ(allocs1, 1);
@@ -584,11 +584,11 @@ TEST(ProtocolTest, MoveAssignmentUnequalPocma) {
   {
     PocmaAllocator<std::byte> alloc1{&allocs1, &deallocs1};
     xyz::protocol<IntLike, PocmaAllocator<std::byte>> p1{std::allocator_arg,
-                                                         alloc1, Tester{0}};
+                                                         alloc1, Tester(0)};
 
     PocmaAllocator<std::byte> alloc2{&allocs2, &deallocs2};
     xyz::protocol<IntLike, PocmaAllocator<std::byte>> p2{std::allocator_arg,
-                                                         alloc2, Tester{10}};
+                                                         alloc2, Tester(10)};
 
     // p1 and p2 are both constructed with different allocators.
     EXPECT_EQ(allocs1, 1);
@@ -634,11 +634,11 @@ TEST(ProtocolTest, SwapUnequalPocs) {
   {
     PocsAllocator<std::byte> alloc1{&allocs1, &deallocs1};
     xyz::protocol<IntLike, PocsAllocator<std::byte>> p1{std::allocator_arg,
-                                                        alloc1, Tester{0}};
+                                                        alloc1, Tester(0)};
 
     PocsAllocator<std::byte> alloc2{&allocs2, &deallocs2};
     xyz::protocol<IntLike, PocsAllocator<std::byte>> p2{std::allocator_arg,
-                                                        alloc2, Tester{10}};
+                                                        alloc2, Tester(10)};
 
     // p1 and p2 were constructed with different allocators.
     EXPECT_EQ(allocs1, 1);
@@ -704,7 +704,7 @@ TEST(ProtocolTest, ConstructionException) {
   bool should_throw{true};
 
   ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
-  EXPECT_THROW((ThrowingProtocol{std::allocator_arg, alloc, Tester{0}}),
+  EXPECT_THROW((ThrowingProtocol{std::allocator_arg, alloc, Tester(0)}),
                TestException);
   // alloc threw before any allocations were performed.
   EXPECT_EQ(allocs, 0);
@@ -767,7 +767,7 @@ TEST(ProtocolTest, EqualMoveConstructionNoException) {
   bool should_throw{false};
 
   ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
-  ThrowingProtocol p1{std::allocator_arg, alloc, Tester{15}};
+  ThrowingProtocol p1{std::allocator_arg, alloc, Tester(15)};
   EXPECT_EQ(allocs, 1);
 
   should_throw = true;
@@ -821,8 +821,8 @@ TEST(ProtocolTest, EqualMoveAssignmentNoException) {
     bool should_throw{false};
 
     ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
-    ThrowingProtocol p1{std::allocator_arg, alloc, Tester{15}};
-    ThrowingProtocol p2{std::allocator_arg, alloc, Tester{35}};
+    ThrowingProtocol p1{std::allocator_arg, alloc, Tester(15)};
+    ThrowingProtocol p2{std::allocator_arg, alloc, Tester(35)};
     EXPECT_EQ(allocs, 2);
 
     // When p1 and p2 have equal allocators, move assignment should

--- a/reflection/allocator_tests.cc
+++ b/reflection/allocator_tests.cc
@@ -406,7 +406,7 @@ TEST(ProtocolTest, SwapUnequal) {
 //   {
 //     TestAlloc alloc1{&allocs, &deallocs};
 //     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-//                                          Tester{25}};
+//                                          Tester(25)};
 //     // Blank is a subset of IntLike.
 //     xyz::protocol<Blank, TestAlloc> p2{p1};
 //     // This is a deep copy still, so space must be allocated once for
@@ -429,7 +429,7 @@ TEST(ProtocolTest, SwapUnequal) {
 //     TestAlloc alloc2{&allocs2, &deallocs2};
 
 //     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-//                                          Tester{25}};
+//                                          Tester(25)};
 //     xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2, p1};
 //     EXPECT_EQ(allocs1, 1);  // Allocated p1.
 //     EXPECT_EQ(allocs2, 1);  // Allocated p2.
@@ -449,7 +449,7 @@ TEST(ProtocolTest, SwapUnequal) {
 //   {
 //     TestAlloc alloc1{&allocs, &deallocs};
 //     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-//                                          Tester{25}};
+//                                          Tester(25)};
 //     xyz::protocol<Blank, TestAlloc> p2{std::move(p1)};
 //     // Even though the interfaces are different, the allocators are the
 //     // same. Move construction is a pointer swap.
@@ -475,7 +475,7 @@ TEST(ProtocolTest, SwapUnequal) {
 //     TestAlloc alloc2{&allocs, &deallocs};
 
 //     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-//                                          Tester{25}};
+//                                          Tester(25)};
 //     xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
 //                                        std::move(p1)};
 //     // Even though we explicitly provide an allocator, they both
@@ -497,7 +497,7 @@ TEST(ProtocolTest, SwapUnequal) {
 //     TestAlloc alloc2{&allocs2, &deallocs2};
 
 //     xyz::protocol<IntLike, TestAlloc> p1{std::allocator_arg, alloc1,
-//                                          Tester{25}};
+//                                          Tester(25)};
 //     xyz::protocol<Blank, TestAlloc> p2{std::allocator_arg, alloc2,
 //                                        std::move(p1)};
 //     // alloc1 != alloc2, so we must perform a new allocation for p2
@@ -719,7 +719,7 @@ TEST(ProtocolTest, ConstructionException) {
 //     bool should_throw{false};
 
 //     ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
-//     ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
+//     ThrowingProtocol p1{std::allocator_arg, alloc, Tester(10)};
 //     // p1 was allocated safely.
 //     EXPECT_EQ(allocs, 1);
 
@@ -742,8 +742,8 @@ TEST(ProtocolTest, ConstructionException) {
 
 //     // p1 and p2 are both constructed without issue.
 //     ThrowingAlloc alloc{&allocs, &deallocs, &should_throw};
-//     ThrowingProtocol p1{std::allocator_arg, alloc, Tester{10}};
-//     ThrowingProtocol p2{std::allocator_arg, alloc, Tester{20}};
+//     ThrowingProtocol p1{std::allocator_arg, alloc, Tester(10)};
+//     ThrowingProtocol p2{std::allocator_arg, alloc, Tester(20)};
 
 //     EXPECT_EQ(allocs, 2);
 //     EXPECT_EQ(deallocs, 0);
@@ -789,7 +789,7 @@ TEST(ProtocolTest, EqualMoveConstructionNoException) {
 //     bool should_throw{false};
 
 //     ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw};
-//     ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
+//     ThrowingProtocol p1{std::allocator_arg, alloc1, Tester(25)};
 
 //     should_throw = true;
 //     ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw};
@@ -848,10 +848,10 @@ TEST(ProtocolTest, EqualMoveAssignmentNoException) {
 //     bool should_throw2{false};
 
 //     ThrowingAlloc alloc1{&allocs1, &deallocs1, &should_throw1};
-//     ThrowingProtocol p1{std::allocator_arg, alloc1, Tester{25}};
+//     ThrowingProtocol p1{std::allocator_arg, alloc1, Tester(25)};
 
 //     ThrowingAlloc alloc2{&allocs2, &deallocs2, &should_throw2};
-//     ThrowingProtocol p2{std::allocator_arg, alloc2, Tester{55}};
+//     ThrowingProtocol p2{std::allocator_arg, alloc2, Tester(55)};
 
 //     EXPECT_EQ(allocs1, 1);
 //     EXPECT_EQ(allocs2, 1);

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -146,18 +146,18 @@ class protocol {
   template <typename T>
   using rebound_traits = std::allocator_traits<rebound<T>>;
 
-  constexpr static bool pocca =
+  static constexpr bool pocca =
       traits::propagate_on_container_copy_assignment::value;
 
-  constexpr static bool pocma =
+  static constexpr bool pocma =
       traits::propagate_on_container_move_assignment::value;
 
-  constexpr static bool pocs = traits::propagate_on_container_swap::value;
+  static constexpr bool pocs = traits::propagate_on_container_swap::value;
 
-  constexpr static bool always_equal = traits::is_always_equal::value;
+  static constexpr bool always_equal = traits::is_always_equal::value;
 
   template <typename T, typename TNorm = std::decay_t<T>, typename... Args>
-  constexpr static TNorm* create(const Alloc& alloc, Args&&... args) {
+  static constexpr TNorm* create(const Alloc& alloc, Args&&... args) {
     rebound<TNorm> new_alloc{alloc};
 
     auto obj = rebound_traits<TNorm>::allocate(new_alloc, 1);
@@ -179,7 +179,7 @@ class protocol {
   };
 
   template <typename T, typename TNorm = std::decay_t<T>>
-  constexpr static vtable vtable_for = {
+  static constexpr vtable vtable_for = {
       .destroy = +[](const Alloc& alloc, void* data) -> void {
         rebound<TNorm> new_alloc{alloc};
         auto* typed = static_cast<TNorm*>(data);
@@ -195,7 +195,7 @@ class protocol {
         return create<TNorm>(alloc, std::move(*static_cast<TNorm*>(data)));
       }};
 
-  constexpr static vtable null_vtable = {
+  static constexpr vtable null_vtable = {
       .destroy = +[](const Alloc&, void*) -> void {},
       .copy = +[](const Alloc&, const void*) -> void* { return nullptr; },
       .move = +[](const Alloc&, void*) -> void* { return nullptr; }};
@@ -210,19 +210,23 @@ class protocol {
 
   protocol() = delete;
 
-  template <typename T>
-    requires(!std::same_as<std::decay_t<T>, protocol> &&
-             detail::meets_interface<T, I> && std::default_initializable<Alloc>)
+  template <typename T, typename TNorm = std::decay_t<T>>
+    requires(!std::same_as<TNorm, protocol> &&
+             is_protocol_conformant_v<I, TNorm> && std::default_initializable<Alloc>)
   constexpr explicit protocol(T&& obj)
       : protocol(std::allocator_arg, Alloc{}, std::forward<T>(obj)) {}
 
   template <typename T>
-    requires(!std::same_as<std::decay_t<T>, protocol> &&
-             detail::meets_interface<T, I>)
+    requires(!std::same_as<TNorm, protocol> &&
+             is_protocol_conformant_v<I, TNorm>)
   constexpr explicit protocol(std::allocator_arg_t, const Alloc& a, T&& obj)
       : alloc_(a),
         obj_(create<T>(alloc_, std::forward<T>(obj))),
         vtable_(&vtable_for<T>) {}
+
+  template <typename T>
+    requires(!std::same_as<std::decay_t<T>, protocol> &&
+    )
 
   constexpr ~protocol() { vtable_->destroy(alloc_, obj_); }
 

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -224,9 +224,33 @@ class protocol {
         obj_(create<T>(alloc_, std::forward<T>(obj))),
         vtable_(&vtable_for<T>) {}
 
-  template <typename T>
+  template <typename T, typename... Args>
     requires(!std::same_as<std::decay_t<T>, protocol> &&
-    )
+             is_protocol_conformant_v<I, T> && std::default_initializable<Alloc>)
+  constexpr explicit protocol(std::in_place_type_t<T>, Args&&... args)
+      : protocol(std::allocator_arg, Alloc{}, std::forward<Args>(args)...) {}
+
+  template <typename T, typename... Args>
+    requires(!std::same_as<std::decay_t<T>, protocol> &&
+             is_protocol_conformant_v<I, T>)
+  constexpr explicit protocol(std::allocator_arg_t, const Alloc& a, std::in_place_type_t<T>, Args&&... args)
+      : alloc_(a),
+        obj_(create<T>(alloc_, std::forward<Args>(args)...)),
+        vtable_(&vtable_for<T>) {}
+
+  template <typename T, typename U, typename... Args>
+    requires(!std::same_as<std::decay_t<T>, protocol> &&
+             is_protocol_conformant_v<I, T> && std::default_initializable<Alloc>)
+  constexpr explicit protocol(std::in_place_type_t<T>, std::initializer_list<U> il, Args&&... args)
+      : protocol(std::allocator_arg, Alloc{}, il, std::forward<Args>(args)...) {}
+
+  template <typename T, typename U, typename... Args>
+    requires(!std::same_as<std::decay_t<T>, protocol> &&
+             is_protocol_conformant_v<I, T>)
+  constexpr explicit protocol(std::allocator_arg_t, const Alloc& a, std::in_place_type_t<T>, std::initializer_list<U> il, Args&&... args)
+      : alloc_(a),
+        obj_(create<T>(alloc_, il, std::forward<Args>(args)...)),
+        vtable_(&vtable_for<T>) {}
 
   constexpr ~protocol() { vtable_->destroy(alloc_, obj_); }
 

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -212,11 +212,12 @@ class protocol {
 
   template <typename T, typename TNorm = std::decay_t<T>>
     requires(!std::same_as<TNorm, protocol> &&
-             is_protocol_conformant_v<I, TNorm> && std::default_initializable<Alloc>)
+             is_protocol_conformant_v<I, TNorm> &&
+             std::default_initializable<Alloc>)
   constexpr explicit protocol(T&& obj)
       : protocol(std::allocator_arg, Alloc{}, std::forward<T>(obj)) {}
 
-  template <typename T>
+  template <typename T, typename TNorm = std::decay_t<T>>
     requires(!std::same_as<TNorm, protocol> &&
              is_protocol_conformant_v<I, TNorm>)
   constexpr explicit protocol(std::allocator_arg_t, const Alloc& a, T&& obj)
@@ -226,28 +227,35 @@ class protocol {
 
   template <typename T, typename... Args>
     requires(!std::same_as<std::decay_t<T>, protocol> &&
-             is_protocol_conformant_v<I, T> && std::default_initializable<Alloc>)
+             is_protocol_conformant_v<I, T> &&
+             std::default_initializable<Alloc>)
   constexpr explicit protocol(std::in_place_type_t<T>, Args&&... args)
       : protocol(std::allocator_arg, Alloc{}, std::forward<Args>(args)...) {}
 
   template <typename T, typename... Args>
     requires(!std::same_as<std::decay_t<T>, protocol> &&
              is_protocol_conformant_v<I, T>)
-  constexpr explicit protocol(std::allocator_arg_t, const Alloc& a, std::in_place_type_t<T>, Args&&... args)
+  constexpr explicit protocol(std::allocator_arg_t, const Alloc& a,
+                              std::in_place_type_t<T>, Args&&... args)
       : alloc_(a),
         obj_(create<T>(alloc_, std::forward<Args>(args)...)),
         vtable_(&vtable_for<T>) {}
 
   template <typename T, typename U, typename... Args>
     requires(!std::same_as<std::decay_t<T>, protocol> &&
-             is_protocol_conformant_v<I, T> && std::default_initializable<Alloc>)
-  constexpr explicit protocol(std::in_place_type_t<T>, std::initializer_list<U> il, Args&&... args)
-      : protocol(std::allocator_arg, Alloc{}, il, std::forward<Args>(args)...) {}
+             is_protocol_conformant_v<I, T> &&
+             std::default_initializable<Alloc>)
+  constexpr explicit protocol(std::in_place_type_t<T>,
+                              std::initializer_list<U> il, Args&&... args)
+      : protocol(std::allocator_arg, Alloc{}, il, std::forward<Args>(args)...) {
+  }
 
   template <typename T, typename U, typename... Args>
     requires(!std::same_as<std::decay_t<T>, protocol> &&
              is_protocol_conformant_v<I, T>)
-  constexpr explicit protocol(std::allocator_arg_t, const Alloc& a, std::in_place_type_t<T>, std::initializer_list<U> il, Args&&... args)
+  constexpr explicit protocol(std::allocator_arg_t, const Alloc& a,
+                              std::in_place_type_t<T>,
+                              std::initializer_list<U> il, Args&&... args)
       : alloc_(a),
         obj_(create<T>(alloc_, il, std::forward<Args>(args)...)),
         vtable_(&vtable_for<T>) {}

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -23,6 +23,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // A C++26-reflection-based implementation of protocol and protocol_view.
 
 #include <algorithm>
+#include <cassert>
+#include <concepts>
 #include <cstddef>
 #include <memory>
 #include <meta>
@@ -136,32 +138,187 @@ inline constexpr bool is_protocol_conformant_v =
 
 template <typename T, typename Allocator = std::allocator<std::byte>>
 class protocol {
+  using traits = std::allocator_traits<Alloc>;
+
+  template <typename T>
+  using rebound = traits::template rebind_alloc<T>;
+
+  template <typename T>
+  using rebound_traits = std::allocator_traits<rebound<T>>;
+
+  constexpr static bool pocca =
+      traits::propagate_on_container_copy_assignment::value;
+
+  constexpr static bool pocma =
+      traits::propagate_on_container_move_assignment::value;
+
+  constexpr static bool pocs = traits::propagate_on_container_swap::value;
+
+  constexpr static bool always_equal = traits::is_always_equal::value;
+
+  template <typename T, typename TNorm = std::decay_t<T>, typename... Args>
+  constexpr static TNorm* create(Alloc& alloc, Args&&... args) {
+    rebound<TNorm> new_alloc{alloc};
+
+    auto obj = rebound_traits<TNorm>::allocate(new_alloc, 1);
+    try {
+      rebound_traits<TNorm>::construct(new_alloc, obj, std::forward<Args>(args)...);
+    } catch (...) {
+      rebound_traits<TNorm>::deallocate(new_alloc, obj, 1);
+      throw;
+    }
+
+    return obj;
+  }
+
+  struct vtable {
+    void (*destroy)(Alloc& alloc, void* data);
+    void* (*copy)(Alloc& alloc, const void* data);
+    void* (*move)(Alloc& alloc, void* data);
+  };
+
+  template <typename T, typename TNorm = std::decay_t<T>>
+  constexpr static vtable vtable_for = {
+      .destroy = +[](Alloc& alloc, void* data) -> void {
+        rebound<TNorm> new_alloc{alloc};
+        auto* typed = static_cast<TNorm*>(data);
+        rebound_traits<TNorm>::destroy(new_alloc, typed);
+        rebound_traits<TNorm>::deallocate(new_alloc, typed, 1);
+      },
+
+      .copy = +[](Alloc& alloc, const void* data) -> void* {
+        return create<TNorm>(alloc, *static_cast<const TNorm*>(data));
+      },
+
+      .move = +[](Alloc& alloc, void* data) -> void* {
+        return create<TNorm>(alloc, std::move(*static_cast<TNorm*>(data)));
+      }};
+
+  constexpr static vtable null_vtable = {
+      .destroy = +[](Alloc&, void*) -> void {},
+      .copy = +[](Alloc&, const void*) -> void* { return nullptr; },
+      .move = +[](Alloc&, void*) -> void* { return nullptr; }};
+
+  [[no_unique_address]] Alloc alloc_;
+
+  void* obj_ = nullptr;
+  const vtable* vtable_ = &null_vtable;
+
  public:
-  protocol() = delete;  // Deleted as `T` is used as an interface type.
+  using allocator_type = Alloc;
 
-  protocol(const protocol&)
-    requires std::is_copy_constructible_v<T>;
+  protocol() = delete;
 
-  protocol(protocol&&);  // Unconstrained
+  template <typename T>
+    requires (!std::same_as<std::decay_t<T>, protocol> && detail::meets_interface<T, I> &&
+             std::default_initializable<Alloc>)
+  constexpr explicit protocol(T && obj)
+      : protocol(std::allocator_arg, Alloc{}, std::forward<T>(obj)) {}
 
-  protocol& operator=(const protocol&)
-    requires std::is_copy_constructible_v<T>;
+  template <typename T>
+    requires (!std::same_as<std::decay_t<T>, protocol> && detail::meets_interface<T, I>)
+  constexpr explicit protocol(std::allocator_arg_t, const Alloc& a, T&& obj)
+      : alloc_(a),
+        obj_(create<T>(alloc_, std::forward<T>(obj))),
+        vtable_(&vtable_for<T>) {}
 
-  protocol& operator=(protocol&&);  // Unconstrained.
+  constexpr ~protocol() { vtable_->destroy(alloc_, obj_); }
 
-  ~protocol();  // Unconstrained.
+  constexpr protocol(const protocol& other)
+    requires std::is_copy_constructible_v<I>
+      : protocol(std::allocator_arg,
+                 traits::select_on_container_copy_construction(other.alloc_),
+                 other) {}
 
-  // Construct from any type U that conforms to the Interface T.
-  template <typename U>
-    requires is_protocol_conformant_v<T, std::remove_cvref_t<U>> &&
-             (!is_protocol_v<std::remove_cvref_t<U>>)
-  explicit protocol(U&& value);
+  constexpr protocol(std::allocator_arg_t, const Alloc& a, const protocol& other)
+    requires std::is_copy_constructible_v<I>
+      : alloc_(a),
+        obj_(other.vtable_->copy(alloc_, other.obj_)),
+        vtable_(other.vtable_) {}
 
-  // Construct a U in place from Ts..., where U conforms to the Interface T.
-  template <typename U, typename... Ts>
-    requires is_protocol_conformant_v<T, std::remove_cvref_t<U>> &&
-             (!is_protocol_v<std::remove_cvref_t<U>>)
-  explicit protocol(std::in_place_type_t<U>, Ts&&... ts);
+  constexpr protocol(protocol&& other) noexcept
+      : protocol(std::allocator_arg, other.alloc_, std::move(other)) {}
+
+  constexpr protocol(std::allocator_arg_t, const Alloc& a,
+           protocol&& other) noexcept(always_equal)
+      : alloc_(a) {
+    if (always_equal || alloc_ == other.alloc_) {
+      obj_ = other.obj_;
+    } else {
+      obj_ = other.vtable_->move(alloc_, other.obj_);
+      other.vtable_->destroy(other.alloc_, other.obj_);
+    }
+
+    other.obj_ = nullptr;
+    other.vtable_ = &null_vtable;
+  }
+
+  constexpr protocol& operator=(const protocol& other)
+    requires std::is_copy_constructible_v<I>
+  {
+    if (this == &other) {
+      return *this;
+    }
+
+    if constexpr (pocca) {
+      void* new_obj = other.vtable_->copy(other.alloc_, other.obj_);
+
+      vtable_->destroy(alloc_, obj_);
+      obj_ = new_obj;
+      alloc_ = other.alloc_;
+    } else {
+      void* new_obj = other.vtable_->copy(alloc_, other.obj_);
+      vtable_->destroy(alloc_, obj_);
+      obj_ = new_obj;
+    }
+    vtable_ = other.vtable_;
+
+    return *this;
+  }
+
+  constexpr protocol& operator=(protocol&& other) noexcept(always_equal || pocma) {
+    if (this == &other) {
+      return *this;
+    }
+
+    if (always_equal || pocma || alloc_ == other.alloc_) {
+      vtable_->destroy(alloc_, obj_);
+      obj_ = other.obj_;
+      if constexpr (pocma) {
+        alloc_ = other.alloc_;
+      }
+    } else {
+      void* new_obj = other.vtable_->move(alloc_, other.obj_);
+      vtable_->destroy(alloc_, obj_);
+      other.vtable_->destroy(other.alloc_, other.obj_);
+
+      obj_ = new_obj;
+    }
+
+    other.obj_ = nullptr;
+    vtable_ = std::exchange(other.vtable_, &null_vtable);
+
+    return *this;
+  }
+
+  constexpr void swap(protocol& other) noexcept(always_equal || pocs) {
+    if constexpr (!always_equal && !pocs) {
+      assert(alloc_ == other.alloc_);
+    }
+
+    using std::swap;
+    if constexpr (pocs) {
+      swap(alloc_, other.alloc_);
+    }
+    swap(obj_, other.obj_);
+    swap(vtable_, other.vtable_);
+  }
+
+  constexpr const Alloc& get_allocator() const { return alloc_; }
+
+  constexpr bool valueless_after_move() const {
+    return obj_ == nullptr;
+  }
 };
 
 template <typename T>

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -136,7 +136,7 @@ template <typename Interface, typename Candidate>
 inline constexpr bool is_protocol_conformant_v =
     is_protocol_conformant<Interface, Candidate>();
 
-template <typename T, typename Allocator = std::allocator<std::byte>>
+template <typename I, typename Alloc = std::allocator<std::byte>>
 class protocol {
   using traits = std::allocator_traits<Alloc>;
 

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -140,6 +140,8 @@ template <typename I, typename Alloc = std::allocator<std::byte>>
 class protocol {
   using traits = std::allocator_traits<Alloc>;
 
+  // When using allocators in a type-erased context, we must rebind
+  // the allocator for whatever type the user provides.
   template <typename T>
   using rebound = traits::template rebind_alloc<T>;
 
@@ -172,12 +174,17 @@ class protocol {
     return obj;
   }
 
+  // Stores necessary functions for rule-of-five implementation.
+  // NOTE: This should be extended/unified with the view vtable.
+  // Maybe the owning vtable can inherit from the view one?
   struct vtable {
     void (*destroy)(const Alloc& alloc, void* data);
     void* (*copy)(const Alloc& alloc, const void* data);
     void* (*move)(const Alloc& alloc, void* data);
   };
 
+  // Creates a vtable for the type T. TNorm is used throughout
+  // this file to create a convenient alias for a decayed type.
   template <typename T, typename TNorm = std::decay_t<T>>
   static constexpr vtable vtable_for = {
       .destroy = +[](const Alloc& alloc, void* data) -> void {
@@ -195,6 +202,8 @@ class protocol {
         return create<TNorm>(alloc, std::move(*static_cast<TNorm*>(data)));
       }};
 
+  // A no-op vtable that is the stand-in for a nullptr vtable. Prevents
+  // redundant null checks throughout the code.
   static constexpr vtable null_vtable = {
       .destroy = +[](const Alloc&, void*) -> void {},
       .copy = +[](const Alloc&, const void*) -> void* { return nullptr; },
@@ -210,6 +219,7 @@ class protocol {
 
   protocol() = delete;
 
+  // Construction from conforming T.
   template <typename T, typename TNorm = std::decay_t<T>>
     requires(!std::same_as<TNorm, protocol> &&
              is_protocol_conformant_v<I, TNorm> &&
@@ -217,6 +227,7 @@ class protocol {
   constexpr explicit protocol(T&& obj)
       : protocol(std::allocator_arg, Alloc{}, std::forward<T>(obj)) {}
 
+  // Allocator-aware construction from conforming T.
   template <typename T, typename TNorm = std::decay_t<T>>
     requires(!std::same_as<TNorm, protocol> &&
              is_protocol_conformant_v<I, TNorm>)
@@ -225,6 +236,7 @@ class protocol {
         obj_(create<T>(alloc_, std::forward<T>(obj))),
         vtable_(&vtable_for<T>) {}
 
+  // In-place construction from conforming T.
   template <typename T, typename... Args>
     requires(!std::same_as<std::decay_t<T>, protocol> &&
              is_protocol_conformant_v<I, T> &&
@@ -232,6 +244,7 @@ class protocol {
   constexpr explicit protocol(std::in_place_type_t<T>, Args&&... args)
       : protocol(std::allocator_arg, Alloc{}, std::forward<Args>(args)...) {}
 
+  // Allocator-aware in-place construction from conforming T.
   template <typename T, typename... Args>
     requires(!std::same_as<std::decay_t<T>, protocol> &&
              is_protocol_conformant_v<I, T>)
@@ -241,6 +254,8 @@ class protocol {
         obj_(create<T>(alloc_, std::forward<Args>(args)...)),
         vtable_(&vtable_for<T>) {}
 
+  // In-place construction needs this overload because templates cannot
+  // deduce initializer lists.
   template <typename T, typename U, typename... Args>
     requires(!std::same_as<std::decay_t<T>, protocol> &&
              is_protocol_conformant_v<I, T> &&
@@ -250,6 +265,7 @@ class protocol {
       : protocol(std::allocator_arg, Alloc{}, il, std::forward<Args>(args)...) {
   }
 
+  // Allocator-aware in-place init-list construction from conforming T.
   template <typename T, typename U, typename... Args>
     requires(!std::same_as<std::decay_t<T>, protocol> &&
              is_protocol_conformant_v<I, T>)
@@ -262,12 +278,14 @@ class protocol {
 
   constexpr ~protocol() { vtable_->destroy(alloc_, obj_); }
 
+  // Copy construction.
   constexpr protocol(const protocol& other)
     requires std::is_copy_constructible_v<I>
       : protocol(std::allocator_arg,
                  traits::select_on_container_copy_construction(other.alloc_),
                  other) {}
 
+  // Allocator-aware copy construction.
   constexpr protocol(std::allocator_arg_t, const Alloc& a,
                      const protocol& other)
     requires std::is_copy_constructible_v<I>
@@ -275,15 +293,19 @@ class protocol {
         obj_(other.vtable_->copy(alloc_, other.obj_)),
         vtable_(other.vtable_) {}
 
+  // Move construction.
   constexpr protocol(protocol&& other) noexcept
       : protocol(std::allocator_arg, other.alloc_, std::move(other)) {}
 
+  // Allocator-aware move construction.
   constexpr protocol(std::allocator_arg_t, const Alloc& a,
                      protocol&& other) noexcept(always_equal)
       : alloc_(a), vtable_(other.vtable_) {
     if (always_equal || alloc_ == other.alloc_) {
+      // Fast path, we can just do a pointer swap.
       obj_ = other.obj_;
     } else {
+      // Slow path, we have to heap allocate and move construct.
       obj_ = other.vtable_->move(alloc_, other.obj_);
       other.vtable_->destroy(other.alloc_, other.obj_);
     }
@@ -292,6 +314,7 @@ class protocol {
     other.vtable_ = &null_vtable;
   }
 
+  // Copy assignment.
   constexpr protocol& operator=(const protocol& other)
     requires std::is_copy_constructible_v<I>
   {
@@ -300,6 +323,7 @@ class protocol {
     }
 
     if constexpr (pocca) {
+      // Allocate before destruction for strong exception safety.
       void* new_obj = other.vtable_->copy(other.alloc_, other.obj_);
 
       vtable_->destroy(alloc_, obj_);
@@ -315,6 +339,7 @@ class protocol {
     return *this;
   }
 
+  // Move assignment.
   constexpr protocol& operator=(protocol&& other) noexcept(always_equal ||
                                                            pocma) {
     if (this == &other) {
@@ -322,12 +347,15 @@ class protocol {
     }
 
     if (always_equal || pocma || alloc_ == other.alloc_) {
+      // Fast path: just swap the pointers and (conditionally) the allocators.
       vtable_->destroy(alloc_, obj_);
       obj_ = other.obj_;
       if constexpr (pocma) {
         alloc_ = other.alloc_;
       }
     } else {
+      // Slow path: heap construct and move the object directly. Allocate first
+      // for strong exception safety.
       void* new_obj = other.vtable_->move(alloc_, other.obj_);
       vtable_->destroy(alloc_, obj_);
       other.vtable_->destroy(other.alloc_, other.obj_);
@@ -343,7 +371,9 @@ class protocol {
 
   constexpr void swap(protocol& other) noexcept(always_equal || pocs) {
     if constexpr (!always_equal && !pocs) {
-      assert(alloc_ == other.alloc_);
+      // The behavior is undefined if the allocators are not equal.
+      assert(alloc_ == other.alloc_ &&
+             "allocators must compare equal or propagate on swap");
     }
 
     using std::swap;
@@ -354,6 +384,7 @@ class protocol {
     swap(vtable_, other.vtable_);
   }
 
+  // Can be discovered by ADL for more optimal swapping than std::swap.
   friend constexpr void swap(protocol& lhs,
                              protocol& rhs) noexcept(always_equal || pocs) {
     return lhs.swap(rhs);

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -157,7 +157,7 @@ class protocol {
   constexpr static bool always_equal = traits::is_always_equal::value;
 
   template <typename T, typename TNorm = std::decay_t<T>, typename... Args>
-  constexpr static TNorm* create(Alloc& alloc, Args&&... args) {
+  constexpr static TNorm* create(const Alloc& alloc, Args&&... args) {
     rebound<TNorm> new_alloc{alloc};
 
     auto obj = rebound_traits<TNorm>::allocate(new_alloc, 1);
@@ -172,32 +172,32 @@ class protocol {
   }
 
   struct vtable {
-    void (*destroy)(Alloc& alloc, void* data);
-    void* (*copy)(Alloc& alloc, const void* data);
-    void* (*move)(Alloc& alloc, void* data);
+    void (*destroy)(const Alloc& alloc, void* data);
+    void* (*copy)(const Alloc& alloc, const void* data);
+    void* (*move)(const Alloc& alloc, void* data);
   };
 
   template <typename T, typename TNorm = std::decay_t<T>>
   constexpr static vtable vtable_for = {
-      .destroy = +[](Alloc& alloc, void* data) -> void {
+      .destroy = +[](const Alloc& alloc, void* data) -> void {
         rebound<TNorm> new_alloc{alloc};
         auto* typed = static_cast<TNorm*>(data);
         rebound_traits<TNorm>::destroy(new_alloc, typed);
         rebound_traits<TNorm>::deallocate(new_alloc, typed, 1);
       },
 
-      .copy = +[](Alloc& alloc, const void* data) -> void* {
+      .copy = +[](const Alloc& alloc, const void* data) -> void* {
         return create<TNorm>(alloc, *static_cast<const TNorm*>(data));
       },
 
-      .move = +[](Alloc& alloc, void* data) -> void* {
+      .move = +[](const Alloc& alloc, void* data) -> void* {
         return create<TNorm>(alloc, std::move(*static_cast<TNorm*>(data)));
       }};
 
   constexpr static vtable null_vtable = {
-      .destroy = +[](Alloc&, void*) -> void {},
-      .copy = +[](Alloc&, const void*) -> void* { return nullptr; },
-      .move = +[](Alloc&, void*) -> void* { return nullptr; }};
+      .destroy = +[](const Alloc&, void*) -> void {},
+      .copy = +[](const Alloc&, const void*) -> void* { return nullptr; },
+      .move = +[](const Alloc&, void*) -> void* { return nullptr; }};
 
   [[no_unique_address]] Alloc alloc_;
 
@@ -312,6 +312,10 @@ class protocol {
     }
     swap(obj_, other.obj_);
     swap(vtable_, other.vtable_);
+  }
+
+  friend constexpr void swap(protocol& lhs, protocol& rhs) noexcept(always_equal || pocs) {
+    return lhs.swap(rhs);
   }
 
   constexpr const Alloc& get_allocator() const { return alloc_; }

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -162,7 +162,8 @@ class protocol {
 
     auto obj = rebound_traits<TNorm>::allocate(new_alloc, 1);
     try {
-      rebound_traits<TNorm>::construct(new_alloc, obj, std::forward<Args>(args)...);
+      rebound_traits<TNorm>::construct(new_alloc, obj,
+                                       std::forward<Args>(args)...);
     } catch (...) {
       rebound_traits<TNorm>::deallocate(new_alloc, obj, 1);
       throw;
@@ -210,13 +211,14 @@ class protocol {
   protocol() = delete;
 
   template <typename T>
-    requires (!std::same_as<std::decay_t<T>, protocol> && detail::meets_interface<T, I> &&
-             std::default_initializable<Alloc>)
-  constexpr explicit protocol(T && obj)
+    requires(!std::same_as<std::decay_t<T>, protocol> &&
+             detail::meets_interface<T, I> && std::default_initializable<Alloc>)
+  constexpr explicit protocol(T&& obj)
       : protocol(std::allocator_arg, Alloc{}, std::forward<T>(obj)) {}
 
   template <typename T>
-    requires (!std::same_as<std::decay_t<T>, protocol> && detail::meets_interface<T, I>)
+    requires(!std::same_as<std::decay_t<T>, protocol> &&
+             detail::meets_interface<T, I>)
   constexpr explicit protocol(std::allocator_arg_t, const Alloc& a, T&& obj)
       : alloc_(a),
         obj_(create<T>(alloc_, std::forward<T>(obj))),
@@ -230,7 +232,8 @@ class protocol {
                  traits::select_on_container_copy_construction(other.alloc_),
                  other) {}
 
-  constexpr protocol(std::allocator_arg_t, const Alloc& a, const protocol& other)
+  constexpr protocol(std::allocator_arg_t, const Alloc& a,
+                     const protocol& other)
     requires std::is_copy_constructible_v<I>
       : alloc_(a),
         obj_(other.vtable_->copy(alloc_, other.obj_)),
@@ -240,7 +243,7 @@ class protocol {
       : protocol(std::allocator_arg, other.alloc_, std::move(other)) {}
 
   constexpr protocol(std::allocator_arg_t, const Alloc& a,
-           protocol&& other) noexcept(always_equal)
+                     protocol&& other) noexcept(always_equal)
       : alloc_(a), vtable_(other.vtable_) {
     if (always_equal || alloc_ == other.alloc_) {
       obj_ = other.obj_;
@@ -276,7 +279,8 @@ class protocol {
     return *this;
   }
 
-  constexpr protocol& operator=(protocol&& other) noexcept(always_equal || pocma) {
+  constexpr protocol& operator=(protocol&& other) noexcept(always_equal ||
+                                                           pocma) {
     if (this == &other) {
       return *this;
     }
@@ -314,15 +318,14 @@ class protocol {
     swap(vtable_, other.vtable_);
   }
 
-  friend constexpr void swap(protocol& lhs, protocol& rhs) noexcept(always_equal || pocs) {
+  friend constexpr void swap(protocol& lhs,
+                             protocol& rhs) noexcept(always_equal || pocs) {
     return lhs.swap(rhs);
   }
 
   constexpr const Alloc& get_allocator() const { return alloc_; }
 
-  constexpr bool valueless_after_move() const {
-    return obj_ == nullptr;
-  }
+  constexpr bool valueless_after_move() const { return obj_ == nullptr; }
 };
 
 template <typename T>

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -241,7 +241,7 @@ class protocol {
 
   constexpr protocol(std::allocator_arg_t, const Alloc& a,
            protocol&& other) noexcept(always_equal)
-      : alloc_(a) {
+      : alloc_(a), vtable_(other.vtable_) {
     if (always_equal || alloc_ == other.alloc_) {
       obj_ = other.obj_;
     } else {

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -248,7 +248,8 @@ class protocol {
              is_protocol_conformant_v<I, T> &&
              std::default_initializable<Alloc>)
   constexpr explicit protocol(std::in_place_type_t<T>, Args&&... args)
-      : protocol(std::allocator_arg, Alloc{}, std::forward<Args>(args)...) {}
+      : protocol(std::allocator_arg, Alloc{}, std::in_place_type<T>,
+                 std::forward<Args>(args)...) {}
 
   // Allocator-aware in-place construction from conforming T.
   template <typename T, typename... Args>
@@ -268,8 +269,8 @@ class protocol {
              std::default_initializable<Alloc>)
   constexpr explicit protocol(std::in_place_type_t<T>,
                               std::initializer_list<U> il, Args&&... args)
-      : protocol(std::allocator_arg, Alloc{}, il, std::forward<Args>(args)...) {
-  }
+      : protocol(std::allocator_arg, Alloc{}, std::in_place_type<T>, il,
+                 std::forward<Args>(args)...) {}
 
   // Allocator-aware in-place init-list construction from conforming T.
   template <typename T, typename U, typename... Args>

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -194,8 +194,14 @@ class protocol {
         rebound_traits<TNorm>::deallocate(new_alloc, typed, 1);
       },
 
+      // Copy construction and assignment should only reach this
+      // if the interface is copy constructible.
       .copy = +[](const Alloc& alloc, const void* data) -> void* {
-        return create<TNorm>(alloc, *static_cast<const TNorm*>(data));
+        if constexpr (std::is_copy_constructible_v<I>) {
+          return create<TNorm>(alloc, *static_cast<const TNorm*>(data));
+        } else {
+          std::unreachable();
+        }
       },
 
       .move = +[](const Alloc& alloc, void* data) -> void* {


### PR DESCRIPTION
Fixes a bug from my allocator implementation where delegating constructors didn't specify `std::in_place_type<T>`.