### PR TITLE
Forward member functions through an owning vtable in protocol

### DIFF
--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -22,12 +22,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // A C++26-reflection-based implementation of protocol and protocol_view.
 //
-// protocol_view has a minimal but working implementation: functions are
-// dispatched at runtime using a vtable.
-//
-// protocol currently supports only compile-time signature checks for member
-// functions; ownership (construction, copy, move, destruction) is
-// allocator-aware and implemented.
+// Both `protocol` and `protocol_view` dispatch member function calls at
+// runtime through a generated vtable; `protocol`'s vtable extends
+// `protocol_view`'s with destroy/copy/move entries used for allocator-aware
+// ownership.
 //
 // Neither implementation currently supports overloaded member functions or
 // operators.
@@ -340,10 +338,11 @@ struct const_view_trampoline<R (*)(const void*, Args...) noexcept(Noexcept), U,
 };
 
 // Builds a vtable for `T` whose entries call through to the corresponding
-// member of `U`. Every entry is populated: protocol_view's constructor only
-// accepts a non-const U (see its `!std::is_const_v<U>` constraint), so a
-// sound pointer to call any member, const or mutating, through is always
-// available.
+// member of `U`. Every entry is populated: both `protocol_view` (whose
+// constructor only accepts a non-const U, see its `!std::is_const_v<U>`
+// constraint) and `protocol` (which stores a decayed, non-const `TNorm`)
+// always hold a mutable pointer, so a sound pointer to call any member,
+// const or mutating, through is always available.
 template <typename T, typename U>
 consteval typename vtable_generator<T>::vtable make_view_vtable() {
   using Vtable = typename vtable_generator<T>::vtable;
@@ -411,9 +410,9 @@ inline constexpr bool is_protocol_conformant_v =
 // ---------------------------------------------------------------------------
 // protocol<I, Allocator>
 //
-// Vtable layouts in `protocol` and `detail::vtable_generator<I>::vtable` are
-// currently inconsistent. Tests for `protocol` in `reflection/protocol_test.cc`
-// only check the thunk's signature.
+// Owning, allocator-aware, value-semantic. Member functions are forwarded
+// through the owning vtable (see `vtable` below). Calling a member function
+// on a valueless (moved-from) `protocol` is a precondition violation.
 // ---------------------------------------------------------------------------
 template <typename I, typename Alloc = std::allocator<std::byte>>
 class protocol
@@ -455,50 +454,79 @@ class protocol
     return obj;
   }
 
-  // Stores necessary functions for rule-of-five implementation.
-  // NOTE: This should be extended/unified with the view vtable.
-  // Maybe the owning vtable can inherit from the view one?
-  struct vtable {
+  using view_vtable = typename detail::vtable_generator<I>::vtable;
+
+  // Extends the generated per-member-function vtable with the entries needed
+  // for ownership. Because it derives from `view_vtable`, the synthesised
+  // member function thunks (which take a `const view_vtable*`) can call
+  // through a `const vtable*` unchanged.
+  struct vtable : view_vtable {
     void (*destroy)(const Alloc& alloc, void* data);
     void* (*copy)(const Alloc& alloc, const void* data);
     void* (*move)(const Alloc& alloc, void* data);
   };
 
+  // Builds the vtable for the stored type `TNorm`: the member function
+  // entries call through to `TNorm`'s conforming member functions and the
+  // ownership entries use the (rebound) allocator.
+  template <typename T, typename TNorm = std::decay_t<T>>
+  static consteval vtable make_vtable_for() {
+    vtable result{};
+    static_cast<view_vtable&>(result) = detail::make_view_vtable<I, TNorm>();
+
+    result.destroy = +[](const Alloc& alloc, void* data) -> void {
+      rebound<TNorm> new_alloc{alloc};
+      auto* typed = static_cast<TNorm*>(data);
+      rebound_traits<TNorm>::destroy(new_alloc, typed);
+      rebound_traits<TNorm>::deallocate(new_alloc, typed, 1);
+    };
+
+    // Copy construction and assignment should only reach this
+    // if the interface is copy constructible.
+    result.copy = +[](const Alloc& alloc, const void* data) -> void* {
+      if constexpr (std::is_copy_constructible_v<I>) {
+        return create<TNorm>(alloc, *static_cast<const TNorm*>(data));
+      } else {
+        std::unreachable();
+      }
+    };
+
+    result.move = +[](const Alloc& alloc, void* data) -> void* {
+      return create<TNorm>(alloc, std::move(*static_cast<TNorm*>(data)));
+    };
+
+    return result;
+  }
+
   // Creates a vtable for the type T. TNorm is used throughout
   // this file to create a convenient alias for a decayed type.
-  template <typename T, typename TNorm = std::decay_t<T>>
-  static constexpr vtable vtable_for = {
-      .destroy = +[](const Alloc& alloc, void* data) -> void {
-        rebound<TNorm> new_alloc{alloc};
-        auto* typed = static_cast<TNorm*>(data);
-        rebound_traits<TNorm>::destroy(new_alloc, typed);
-        rebound_traits<TNorm>::deallocate(new_alloc, typed, 1);
-      },
-
-      // Copy construction and assignment should only reach this
-      // if the interface is copy constructible.
-      .copy = +[](const Alloc& alloc, const void* data) -> void* {
-        if constexpr (std::is_copy_constructible_v<I>) {
-          return create<TNorm>(alloc, *static_cast<const TNorm*>(data));
-        } else {
-          std::unreachable();
-        }
-      },
-
-      .move = +[](const Alloc& alloc, void* data) -> void* {
-        return create<TNorm>(alloc, std::move(*static_cast<TNorm*>(data)));
-      }};
+  template <typename T>
+  static constexpr vtable vtable_for = make_vtable_for<T>();
 
   // A no-op vtable that is the stand-in for a nullptr vtable. Prevents
-  // redundant null checks throughout the code.
-  static constexpr vtable null_vtable = {
-      .destroy = +[](const Alloc&, void*) -> void {},
-      .copy = +[](const Alloc&, const void*) -> void* { return nullptr; },
-      .move = +[](const Alloc&, void*) -> void* { return nullptr; }};
+  // redundant null checks in the special member functions. The member
+  // function entries are left null: calling a member function on a
+  // valueless protocol is a precondition violation.
+  static consteval vtable make_null_vtable() {
+    vtable result{};
+    result.destroy = +[](const Alloc&, void*) -> void {};
+    result.copy = +[](const Alloc&, const void*) -> void* { return nullptr; };
+    result.move = +[](const Alloc&, void*) -> void* { return nullptr; };
+    return result;
+  }
+
+  static constexpr vtable null_vtable = make_null_vtable();
+
+  // Grants the synthesised member thunks access to `object_`/`vtable_` so
+  // they can locate and call through the matching vtable entry.
+  template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
+            typename Vtable, std::meta::info Member, bool IsConst,
+            bool IsNoexcept>
+  friend struct detail::method_thunk;
 
   [[no_unique_address]] Alloc alloc_;
 
-  void* obj_ = nullptr;
+  void* object_ = nullptr;
   const vtable* vtable_ = &null_vtable;
 
  public:
@@ -520,7 +548,7 @@ class protocol
              is_protocol_conformant_v<I, TNorm>)
   constexpr explicit protocol(std::allocator_arg_t, const Alloc& a, T&& obj)
       : alloc_(a),
-        obj_(create<T>(alloc_, std::forward<T>(obj))),
+        object_(create<T>(alloc_, std::forward<T>(obj))),
         vtable_(&vtable_for<T>) {}
 
   // In-place construction from conforming T.
@@ -529,7 +557,8 @@ class protocol
              is_protocol_conformant_v<I, T> &&
              std::default_initializable<Alloc>)
   constexpr explicit protocol(std::in_place_type_t<T>, Args&&... args)
-      : protocol(std::allocator_arg, Alloc{}, std::forward<Args>(args)...) {}
+      : protocol(std::allocator_arg, Alloc{}, std::in_place_type<T>,
+                 std::forward<Args>(args)...) {}
 
   // Allocator-aware in-place construction from conforming T.
   template <typename T, typename... Args>
@@ -538,7 +567,7 @@ class protocol
   constexpr explicit protocol(std::allocator_arg_t, const Alloc& a,
                               std::in_place_type_t<T>, Args&&... args)
       : alloc_(a),
-        obj_(create<T>(alloc_, std::forward<Args>(args)...)),
+        object_(create<T>(alloc_, std::forward<Args>(args)...)),
         vtable_(&vtable_for<T>) {}
 
   // In-place construction needs this overload because templates cannot
@@ -549,8 +578,8 @@ class protocol
              std::default_initializable<Alloc>)
   constexpr explicit protocol(std::in_place_type_t<T>,
                               std::initializer_list<U> il, Args&&... args)
-      : protocol(std::allocator_arg, Alloc{}, il, std::forward<Args>(args)...) {
-  }
+      : protocol(std::allocator_arg, Alloc{}, std::in_place_type<T>, il,
+                 std::forward<Args>(args)...) {}
 
   // Allocator-aware in-place init-list construction from conforming T.
   template <typename T, typename U, typename... Args>
@@ -560,10 +589,10 @@ class protocol
                               std::in_place_type_t<T>,
                               std::initializer_list<U> il, Args&&... args)
       : alloc_(a),
-        obj_(create<T>(alloc_, il, std::forward<Args>(args)...)),
+        object_(create<T>(alloc_, il, std::forward<Args>(args)...)),
         vtable_(&vtable_for<T>) {}
 
-  constexpr ~protocol() { vtable_->destroy(alloc_, obj_); }
+  constexpr ~protocol() { vtable_->destroy(alloc_, object_); }
 
   // Copy construction.
   constexpr protocol(const protocol& other)
@@ -577,7 +606,7 @@ class protocol
                      const protocol& other)
     requires std::is_copy_constructible_v<I>
       : alloc_(a),
-        obj_(other.vtable_->copy(alloc_, other.obj_)),
+        object_(other.vtable_->copy(alloc_, other.object_)),
         vtable_(other.vtable_) {}
 
   // Move construction.
@@ -590,14 +619,14 @@ class protocol
       : alloc_(a), vtable_(other.vtable_) {
     if (always_equal || alloc_ == other.alloc_) {
       // Fast path, we can just do a pointer swap.
-      obj_ = other.obj_;
+      object_ = other.object_;
     } else {
       // Slow path, we have to heap allocate and move construct.
-      obj_ = other.vtable_->move(alloc_, other.obj_);
-      other.vtable_->destroy(other.alloc_, other.obj_);
+      object_ = other.vtable_->move(alloc_, other.object_);
+      other.vtable_->destroy(other.alloc_, other.object_);
     }
 
-    other.obj_ = nullptr;
+    other.object_ = nullptr;
     other.vtable_ = &null_vtable;
   }
 
@@ -611,15 +640,15 @@ class protocol
 
     if constexpr (pocca) {
       // Allocate before destruction for strong exception safety.
-      void* new_obj = other.vtable_->copy(other.alloc_, other.obj_);
+      void* new_object = other.vtable_->copy(other.alloc_, other.object_);
 
-      vtable_->destroy(alloc_, obj_);
-      obj_ = new_obj;
+      vtable_->destroy(alloc_, object_);
+      object_ = new_object;
       alloc_ = other.alloc_;
     } else {
-      void* new_obj = other.vtable_->copy(alloc_, other.obj_);
-      vtable_->destroy(alloc_, obj_);
-      obj_ = new_obj;
+      void* new_object = other.vtable_->copy(alloc_, other.object_);
+      vtable_->destroy(alloc_, object_);
+      object_ = new_object;
     }
     vtable_ = other.vtable_;
 
@@ -635,22 +664,22 @@ class protocol
 
     if (always_equal || pocma || alloc_ == other.alloc_) {
       // Fast path: just swap the pointers and (conditionally) the allocators.
-      vtable_->destroy(alloc_, obj_);
-      obj_ = other.obj_;
+      vtable_->destroy(alloc_, object_);
+      object_ = other.object_;
       if constexpr (pocma) {
         alloc_ = other.alloc_;
       }
     } else {
       // Slow path: heap construct and move the object directly. Allocate first
       // for strong exception safety.
-      void* new_obj = other.vtable_->move(alloc_, other.obj_);
-      vtable_->destroy(alloc_, obj_);
-      other.vtable_->destroy(other.alloc_, other.obj_);
+      void* new_object = other.vtable_->move(alloc_, other.object_);
+      vtable_->destroy(alloc_, object_);
+      other.vtable_->destroy(other.alloc_, other.object_);
 
-      obj_ = new_obj;
+      object_ = new_object;
     }
 
-    other.obj_ = nullptr;
+    other.object_ = nullptr;
     vtable_ = std::exchange(other.vtable_, &null_vtable);
 
     return *this;
@@ -667,7 +696,7 @@ class protocol
     if constexpr (pocs) {
       swap(alloc_, other.alloc_);
     }
-    swap(obj_, other.obj_);
+    swap(object_, other.object_);
     swap(vtable_, other.vtable_);
   }
 
@@ -679,7 +708,7 @@ class protocol
 
   constexpr const Alloc& get_allocator() const { return alloc_; }
 
-  constexpr bool valueless_after_move() const { return obj_ == nullptr; }
+  constexpr bool valueless_after_move() const { return object_ == nullptr; }
 };
 
 // ---------------------------------------------------------------------------

--- a/reflection/protocol_test.cc
+++ b/reflection/protocol_test.cc
@@ -6,11 +6,14 @@
 #include <gtest/gtest.h>
 
 #include <concepts>
+#include <cstddef>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
+
+#include "tracking_allocator.h"
 
 using xyz::reflection::is_protocol_conformant;
 using xyz::reflection::is_protocol_v;
@@ -549,17 +552,19 @@ TEST(ReflectionProtocolViewTest, MixedConstAndMutatingMemberFunctions) {
   EXPECT_EQ(c.value, 7);
 }
 
-// Member function signature tests for protocol.
+// Member function forwarding tests for protocol.
 
 TEST(ReflectionProtocolTest, ConstMemberFunction) {
   struct Interface {
     int get_value() const;
   };
 
-  // TODO(jbcoe): replace static assertion with runtime test.
-  static_assert(requires(const protocol<Interface>& p) {
-    { p.get_value() } -> std::same_as<int>;
-  });
+  struct Conforming {
+    int get_value() const { return 42; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.get_value(), 42);
 }
 
 TEST(ReflectionProtocolTest, NonConstMemberFunctionNotInvocableFromConst) {
@@ -575,12 +580,21 @@ TEST(ReflectionProtocolTest, NonConstMemberFunctionNotInvocableFromConst) {
 TEST(ReflectionProtocolTest, SingleParameterMemberFunction) {
   struct Interface {
     void update(int value);
+    int get() const;
   };
 
-  // TODO(jbcoe): replace static assertion with runtime test.
-  static_assert(requires(protocol<Interface>& p) {
-    { p.update(0) } -> std::same_as<void>;
-  });
+  struct Conforming {
+    int last_value = 0;
+
+    void update(int value) { last_value = value; }
+
+    int get() const { return last_value; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  p.update(42);
+  EXPECT_EQ(p.get(), 42);
+  static_assert(!noexcept(p.update(1)));
 }
 
 TEST(ReflectionProtocolTest, NoexceptMemberFunction) {
@@ -588,10 +602,13 @@ TEST(ReflectionProtocolTest, NoexceptMemberFunction) {
     double compute(double input) noexcept;
   };
 
-  // TODO(jbcoe): replace static assertion with runtime test.
-  static_assert(requires(protocol<Interface>& p) {
-    { p.compute(0.0) } noexcept -> std::same_as<double>;
-  });
+  struct Conforming {
+    double compute(double input) noexcept { return input * 2.0; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.compute(21.0), 42.0);
+  static_assert(noexcept(p.compute(1.0)));
 }
 
 TEST(ReflectionProtocolTest, MultiParameterMemberFunction) {
@@ -599,21 +616,31 @@ TEST(ReflectionProtocolTest, MultiParameterMemberFunction) {
     int add(int a, int b) const;
   };
 
-  // TODO(jbcoe): replace static assertion with runtime test.
-  static_assert(requires(const protocol<Interface>& p) {
-    { p.add(1, 2) } -> std::same_as<int>;
-  });
+  struct Conforming {
+    int add(int a, int b) const { return a + b; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.add(1, 2), 3);
 }
 
 TEST(ReflectionProtocolTest, VoidMemberFunction) {
   struct Interface {
     void reset();
+    bool was_reset() const;
   };
 
-  // TODO(jbcoe): replace static assertion with runtime test.
-  static_assert(requires(protocol<Interface>& p) {
-    { p.reset() } -> std::same_as<void>;
-  });
+  struct Conforming {
+    bool reset_flag = false;
+
+    void reset() { reset_flag = true; }
+
+    bool was_reset() const { return reset_flag; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  p.reset();
+  EXPECT_TRUE(p.was_reset());
 }
 
 TEST(ReflectionProtocolTest, MultipleMemberFunctions) {
@@ -622,10 +649,238 @@ TEST(ReflectionProtocolTest, MultipleMemberFunctions) {
     double multiply(double x, double y) const noexcept;
   };
 
-  // TODO(jbcoe): replace static assertion with runtime test.
-  static_assert(requires(const protocol<Interface>& p) {
-    { p.add(1.0, 2.0) } noexcept -> std::same_as<double>;
-    { p.multiply(3.0, 4.0) } noexcept -> std::same_as<double>;
-  });
+  struct Conforming {
+    double add(double x, double y) const noexcept { return x + y; }
+
+    double multiply(double x, double y) const noexcept { return x * y; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.add(1.0, 2.0), 3.0);
+  EXPECT_EQ(p.multiply(3.0, 4.0), 12.0);
+}
+
+TEST(ReflectionProtocolTest, MixedConstAndMutatingMemberFunctions) {
+  struct Interface {
+    int get() const;
+    void set(int value);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.get(), 0);
+  p.set(7);
+  EXPECT_EQ(p.get(), 7);
+}
+
+TEST(ReflectionProtocolTest, ForwardingAfterCopyConstruction) {
+  struct Interface {
+    int get() const;
+    void set(int value);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  protocol<Interface> a(Conforming{});
+  a.set(1);
+  protocol<Interface> b(a);
+  b.set(2);
+
+  // protocol owns a copy of the underlying object, so copies are
+  // independent of one another.
+  EXPECT_EQ(a.get(), 1);
+  EXPECT_EQ(b.get(), 2);
+}
+
+TEST(ReflectionProtocolTest, ForwardingAfterMoveConstruction) {
+  struct Interface {
+    int get() const;
+    void set(int value);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  protocol<Interface> a(Conforming{});
+  a.set(5);
+  protocol<Interface> b(std::move(a));
+
+  EXPECT_EQ(b.get(), 5);
+  EXPECT_TRUE(a.valueless_after_move());
+}
+
+TEST(ReflectionProtocolTest, ForwardingAfterCopyAssignment) {
+  struct Interface {
+    int get() const;
+    void set(int value);
+  };
+
+  // Counter and Doubler both conform to Interface but have different
+  // semantics for set(), so we can tell whether copy assignment updated
+  // the vtable pointer.
+  struct Counter {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  struct Doubler {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value * 2; }
+  };
+
+  protocol<Interface> a(Counter{});
+  protocol<Interface> b(Doubler{});
+
+  a = b;
+  a.set(10);
+  EXPECT_EQ(a.get(), 20);  // a now has Doubler's semantics.
+}
+
+TEST(ReflectionProtocolTest, ForwardingAfterMoveAssignment) {
+  struct Interface {
+    int get() const;
+    void set(int value);
+  };
+
+  struct Counter {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  struct Doubler {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value * 2; }
+  };
+
+  protocol<Interface> a(Counter{});
+  protocol<Interface> b(Doubler{});
+
+  a = std::move(b);
+  a.set(10);
+  EXPECT_EQ(a.get(), 20);  // a now has Doubler's semantics.
+  EXPECT_TRUE(b.valueless_after_move());
+}
+
+TEST(ReflectionProtocolTest, ForwardingAfterSwap) {
+  struct Interface {
+    int get() const;
+    void set(int value);
+  };
+
+  struct Counter {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  struct Doubler {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value * 2; }
+  };
+
+  protocol<Interface> a(Counter{});
+  protocol<Interface> b(Doubler{});
+
+  using std::swap;
+  swap(a, b);
+
+  a.set(10);
+  EXPECT_EQ(a.get(), 20);  // a now behaves like Doubler.
+
+  b.set(10);
+  EXPECT_EQ(b.get(), 10);  // b now behaves like Counter.
+}
+
+TEST(ReflectionProtocolTest, ForwardingWithInPlaceConstruction) {
+  struct Interface {
+    int get() const;
+  };
+
+  struct Conforming {
+    int value;
+
+    explicit Conforming(int initial_value) : value(initial_value) {}
+
+    int get() const { return value; }
+  };
+
+  protocol<Interface> p(std::in_place_type<Conforming>, 42);
+  EXPECT_EQ(p.get(), 42);
+}
+
+TEST(ReflectionProtocolTest, ForwardingWithCustomAllocator) {
+  struct Interface {
+    int get() const;
+  };
+
+  struct Conforming {
+    int value;
+
+    explicit Conforming(int initial_value) : value(initial_value) {}
+
+    int get() const { return value; }
+  };
+
+  unsigned allocs = 0;
+  unsigned deallocs = 0;
+  xyz::TrackingAllocator<std::byte> alloc{&allocs, &deallocs};
+
+  protocol<Interface, xyz::TrackingAllocator<std::byte>> p(
+      std::allocator_arg, alloc, Conforming(42));
+
+  EXPECT_EQ(p.get(), 42);
+  EXPECT_EQ(allocs, 1);
+}
+
+TEST(ReflectionProtocolTest, ConstMemberFunctionOnConstProtocol) {
+  struct Interface {
+    int get_value() const;
+  };
+
+  struct Conforming {
+    int get_value() const { return 42; }
+  };
+
+  const protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.get_value(), 42);
+
+  // A non-const member function is still not invocable on a const protocol;
+  // that assertion is already covered above by
+  // NonConstMemberFunctionNotInvocableFromConst.
 }
 }  // namespace


### PR DESCRIPTION
Adds an owning vtable to the reflection implementation so `protocol` forwards member function calls, as `protocol_view` already does.

`protocol`'s private `vtable` now inherits from `detail::vtable_generator<I>::vtable`, the generated per-member-function vtable `protocol_view` already uses, and adds the `destroy`/`copy`/`move` entries. Existing trampolines are reused as-is via the derived-to-base pointer conversion. Overloads and `protocol_view<const T>` remain out of scope.

Adds runtime forwarding tests for mixed const/mutating members, copy/move/swap, in-place construction, an allocator, and calls through a `const protocol`.

Closes #201.
