### PR TITLE
Make synthesised member thunks non-copyable

### DIFF
--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -154,6 +154,16 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Member,
   static constexpr std::meta::info vtable_entry =
       find_vtable_member<^^Vtable, Member>();
 
+  // Copies detach the thunk from its enclosing object, so calling one is
+  // undefined behaviour; deleting the copy and move operations turns that
+  // misuse into a compile-time error.
+  method_thunk() = default;
+  method_thunk(const method_thunk&) = delete;
+  method_thunk(method_thunk&&) = delete;
+  method_thunk& operator=(const method_thunk&) = delete;
+  method_thunk& operator=(method_thunk&&) = delete;
+  ~method_thunk() = default;
+
   // Provides member-function call syntax. Recovers the EnclosingType pointer
   // through the vanishing-this-pointer cast, widens it to the enclosing
   // protocol/protocol_view object, then calls through its stored vtable
@@ -566,7 +576,9 @@ class protocol
 
   constexpr ~protocol() { vtable_->destroy(alloc_, obj_); }
 
-  // Copy construction.
+  // Copy construction. The wrapper bases are intentionally left
+  // default-initialised because the member thunks are non-copyable (see
+  // `method_thunk`).
   constexpr protocol(const protocol& other)
     requires std::is_copy_constructible_v<I>
       : protocol(std::allocator_arg,
@@ -695,11 +707,29 @@ class protocol_view
   // `protocol_view` would be empty.
   protocol_view() = delete;
 
-  // Remaining special member functions are defaulted.
-  protocol_view(const protocol_view&) = default;
-  protocol_view(protocol_view&&) noexcept = default;
-  protocol_view& operator=(const protocol_view&) = default;
-  protocol_view& operator=(protocol_view&&) noexcept = default;
+  // Remaining special member functions are user-provided because the
+  // synthesised member thunks are non-copyable (see `method_thunk`): a
+  // copy/move of a `protocol_view` copies the viewed pointer and vtable
+  // pointer only, and the thunk bases are re-created by
+  // default-initialisation. Moving is the same as copying (non-owning view).
+  protocol_view(const protocol_view& other) noexcept
+      : object_(other.object_), vtable_(other.vtable_) {}
+
+  protocol_view(protocol_view&& other) noexcept
+      : object_(other.object_), vtable_(other.vtable_) {}
+
+  protocol_view& operator=(const protocol_view& other) noexcept {
+    object_ = other.object_;
+    vtable_ = other.vtable_;
+    return *this;
+  }
+
+  protocol_view& operator=(protocol_view&& other) noexcept {
+    object_ = other.object_;
+    vtable_ = other.vtable_;
+    return *this;
+  }
+
   ~protocol_view() = default;
 
   // Construct from any non-const type U that conforms to the Interface T.

--- a/reflection/protocol_test.cc
+++ b/reflection/protocol_test.cc
@@ -110,6 +110,166 @@ TEST(ReflectionProtocolTest,
   static_assert(std::is_move_assignable_v<protocol<D>>);
 }
 
+TEST(ReflectionProtocolViewTest, MemberThunksAreNotCopyableOrMovable) {
+  // A copied thunk would be detached from its enclosing protocol_view, so
+  // calling it would be undefined behaviour (the vanishing-this-pointer
+  // trick relies on the thunk living inside its wrapper). Deleting the
+  // thunk's copy and move operations turns that misuse into a compile-time
+  // error instead.
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  Conforming c;
+  protocol_view<A> view(c);
+
+  static_assert(!std::is_copy_constructible_v<decltype(view.get)>);
+  static_assert(!std::is_move_constructible_v<decltype(view.get)>);
+  static_assert(!std::is_copy_assignable_v<decltype(view.get)>);
+  static_assert(!std::is_move_assignable_v<decltype(view.get)>);
+
+  static_assert(!std::is_copy_constructible_v<decltype(view.set)>);
+  static_assert(!std::is_move_constructible_v<decltype(view.set)>);
+  static_assert(!std::is_copy_assignable_v<decltype(view.set)>);
+  static_assert(!std::is_move_assignable_v<decltype(view.set)>);
+
+  // Needed so wrappers can be default-initialised.
+  static_assert(std::is_default_constructible_v<decltype(view.get)>);
+  static_assert(std::is_default_constructible_v<decltype(view.set)>);
+}
+
+TEST(ReflectionProtocolTest, MemberThunksAreNotCopyableOrMovable) {
+  // A copied thunk would be detached from its enclosing protocol, so calling
+  // it would be undefined behaviour (the vanishing-this-pointer trick relies
+  // on the thunk living inside its wrapper). Deleting the thunk's copy and
+  // move operations turns that misuse into a compile-time error instead.
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  protocol<A> p(Conforming{});
+
+  static_assert(!std::is_copy_constructible_v<decltype(p.get)>);
+  static_assert(!std::is_move_constructible_v<decltype(p.get)>);
+  static_assert(!std::is_copy_assignable_v<decltype(p.get)>);
+  static_assert(!std::is_move_assignable_v<decltype(p.get)>);
+
+  static_assert(!std::is_copy_constructible_v<decltype(p.set)>);
+  static_assert(!std::is_move_constructible_v<decltype(p.set)>);
+  static_assert(!std::is_copy_assignable_v<decltype(p.set)>);
+  static_assert(!std::is_move_assignable_v<decltype(p.set)>);
+
+  // Needed so wrappers can be default-initialised.
+  static_assert(std::is_default_constructible_v<decltype(p.get)>);
+  static_assert(std::is_default_constructible_v<decltype(p.set)>);
+}
+
+TEST(ReflectionProtocolViewTest, CopyAndMoveRemainNothrow) {
+  // protocol_view's user-provided special member functions must remain
+  // nothrow even though the (non-copyable) thunk bases are
+  // default-initialised rather than copied.
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  static_assert(std::is_nothrow_copy_constructible_v<protocol_view<A>>);
+  static_assert(std::is_nothrow_move_constructible_v<protocol_view<A>>);
+  static_assert(std::is_nothrow_copy_assignable_v<protocol_view<A>>);
+  static_assert(std::is_nothrow_move_assignable_v<protocol_view<A>>);
+}
+
+TEST(ReflectionProtocolViewTest, CopiedViewCallsThroughToViewedObject) {
+  // protocol_view is non-owning: every copy/move should still dispatch to
+  // the same underlying object.
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  Conforming c;
+  protocol_view<A> view(c);
+
+  protocol_view<A> copy_constructed(view);
+  copy_constructed.set(1);
+  EXPECT_EQ(view.get(), 1);
+  EXPECT_EQ(c.value, 1);
+
+  protocol_view<A> move_constructed(std::move(copy_constructed));
+  move_constructed.set(2);
+  EXPECT_EQ(view.get(), 2);
+  EXPECT_EQ(c.value, 2);
+
+  Conforming other;
+  protocol_view<A> other_view(other);
+  other_view = view;
+  other_view.set(3);
+  EXPECT_EQ(view.get(), 3);
+  EXPECT_EQ(c.value, 3);
+
+  Conforming yet_another;
+  protocol_view<A> yet_another_view(yet_another);
+  yet_another_view = std::move(other_view);
+  yet_another_view.set(4);
+  EXPECT_EQ(view.get(), 4);
+  EXPECT_EQ(c.value, 4);
+}
+
+TEST(ReflectionProtocolTest, CopyAndMoveConstructibleWithNonCopyableThunks) {
+  // `protocol`'s special member functions never copy the wrapper bases, so
+  // it remains copyable and movable even though its member thunks are not.
+  // `protocol`'s member thunks cannot yet be invoked at runtime (see the
+  // "Vtable layouts ... are currently inconsistent" note above the
+  // `protocol` class), so this only exercises construction.
+  // TODO(jbcoe): check that copies are independent once protocol's member
+  // thunks are wired up to its own storage.
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  protocol<A> original(Conforming{});
+  protocol<A> copy_constructed(original);
+  protocol<A> move_constructed(std::move(copy_constructed));
+  EXPECT_TRUE(copy_constructed.valueless_after_move());
+  EXPECT_FALSE(move_constructed.valueless_after_move());
+  EXPECT_FALSE(original.valueless_after_move());
+}
+
 // ---------------------------------------------------------------------------
 // Conformance check tests.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #202.

The synthesised callable members in `reflection/protocol.hh` recover their enclosing `protocol`/`protocol_view` from `this`, so a copied member is detached and calling it is undefined behaviour.

- `detail::method_thunk`: delete the copy and move constructors and assignment operators (keeping a defaulted default constructor so the wrapper bases stay default-initialisable). `auto f = view.foo;` is now a compile error.
- `protocol_view`: replace the defaulted copy/move operations, which the change above would have deleted, with user-provided ones that copy `object_`/`vtable_` and leave the thunk bases default-initialised. Still `noexcept`.
- `protocol`: no change needed; its special member functions already never touch the wrapper bases.
- Tests: the member thunks of `protocol` and `protocol_view` are not copyable, movable or assignable; `protocol_view` copy/move remain `noexcept` and copies dispatch to the same viewed object; `protocol` copy/move still compile with the non-copyable bases.

Consequence: `protocol_view` is no longer trivially copyable, since a trivially copyable type must trivially copy every subobject.
