### PR TITLE
Make synthesised member thunks non-detachable while keeping protocol_view trivially copyable

### DIFF
--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -177,6 +177,15 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Member,
     return vtable->[:entry:](protocol_object->object_,
                              std::forward<Args>(args)...);
   }
+
+ private:
+  friend EnclosingType;
+  method_thunk() = default;
+  ~method_thunk() = default;
+  method_thunk(const method_thunk&) = default;
+  method_thunk(method_thunk&&) = default;
+  method_thunk& operator=(const method_thunk&) = default;
+  method_thunk& operator=(method_thunk&&) = default;
 };
 
 template <bool Noexcept, typename R, typename... Args>

--- a/reflection/protocol_test.cc
+++ b/reflection/protocol_test.cc
@@ -129,6 +129,192 @@ TEST(ReflectionProtocolTest,
   static_assert(std::is_move_assignable_v<protocol<D>>);
 }
 
+TEST(ReflectionProtocolViewTest, IsTriviallyCopyable) {
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  static_assert(std::is_trivially_copyable_v<protocol_view<A>>);
+  static_assert(std::is_trivially_copy_constructible_v<protocol_view<A>>);
+  static_assert(std::is_trivially_move_constructible_v<protocol_view<A>>);
+  static_assert(std::is_trivially_copy_assignable_v<protocol_view<A>>);
+  static_assert(std::is_trivially_move_assignable_v<protocol_view<A>>);
+  static_assert(std::is_trivially_destructible_v<protocol_view<A>>);
+  static_assert(std::is_nothrow_copy_constructible_v<protocol_view<A>>);
+  static_assert(std::is_nothrow_move_constructible_v<protocol_view<A>>);
+  static_assert(std::is_nothrow_copy_assignable_v<protocol_view<A>>);
+  static_assert(std::is_nothrow_move_assignable_v<protocol_view<A>>);
+
+  static_assert(std::is_trivially_copyable_v<protocol_view<const A>>);
+  static_assert(std::is_trivially_copy_constructible_v<protocol_view<const A>>);
+  static_assert(std::is_trivially_move_constructible_v<protocol_view<const A>>);
+  static_assert(std::is_trivially_copy_assignable_v<protocol_view<const A>>);
+  static_assert(std::is_trivially_move_assignable_v<protocol_view<const A>>);
+  static_assert(std::is_trivially_destructible_v<protocol_view<const A>>);
+  static_assert(std::is_nothrow_copy_constructible_v<protocol_view<const A>>);
+  static_assert(std::is_nothrow_move_constructible_v<protocol_view<const A>>);
+  static_assert(std::is_nothrow_copy_assignable_v<protocol_view<const A>>);
+  static_assert(std::is_nothrow_move_assignable_v<protocol_view<const A>>);
+}
+
+TEST(ReflectionProtocolViewTest, MemberThunksCannotBeDetached) {
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  Conforming c;
+  protocol_view<A> view(c);
+
+  static_assert(!std::is_copy_constructible_v<decltype(view.get)>);
+  static_assert(!std::is_move_constructible_v<decltype(view.get)>);
+  static_assert(!std::is_copy_assignable_v<decltype(view.get)>);
+  static_assert(!std::is_move_assignable_v<decltype(view.get)>);
+  static_assert(!std::is_default_constructible_v<decltype(view.get)>);
+  static_assert(!std::is_destructible_v<decltype(view.get)>);
+  static_assert(std::is_trivially_copyable_v<decltype(view.get)>);
+
+  static_assert(!std::is_copy_constructible_v<decltype(view.set)>);
+  static_assert(!std::is_move_constructible_v<decltype(view.set)>);
+  static_assert(!std::is_copy_assignable_v<decltype(view.set)>);
+  static_assert(!std::is_move_assignable_v<decltype(view.set)>);
+  static_assert(!std::is_default_constructible_v<decltype(view.set)>);
+  static_assert(!std::is_destructible_v<decltype(view.set)>);
+  static_assert(std::is_trivially_copyable_v<decltype(view.set)>);
+
+  view.set(7);
+  const auto& get = view.get;
+  EXPECT_EQ(get(), 7);
+}
+
+TEST(ReflectionProtocolTest, MemberThunksCannotBeDetached) {
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  protocol<A> p(Conforming{});
+
+  static_assert(!std::is_copy_constructible_v<decltype(p.get)>);
+  static_assert(!std::is_move_constructible_v<decltype(p.get)>);
+  static_assert(!std::is_copy_assignable_v<decltype(p.get)>);
+  static_assert(!std::is_move_assignable_v<decltype(p.get)>);
+  static_assert(!std::is_default_constructible_v<decltype(p.get)>);
+  static_assert(!std::is_destructible_v<decltype(p.get)>);
+  static_assert(std::is_trivially_copyable_v<decltype(p.get)>);
+
+  static_assert(!std::is_copy_constructible_v<decltype(p.set)>);
+  static_assert(!std::is_move_constructible_v<decltype(p.set)>);
+  static_assert(!std::is_copy_assignable_v<decltype(p.set)>);
+  static_assert(!std::is_move_assignable_v<decltype(p.set)>);
+  static_assert(!std::is_default_constructible_v<decltype(p.set)>);
+  static_assert(!std::is_destructible_v<decltype(p.set)>);
+  static_assert(std::is_trivially_copyable_v<decltype(p.set)>);
+
+  p.set(7);
+  const auto& get = p.get;
+  EXPECT_EQ(get(), 7);
+}
+
+TEST(ReflectionProtocolViewTest, CopiedViewCallsThroughToViewedObject) {
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  Conforming c;
+  protocol_view<A> view(c);
+
+  protocol_view<A> copy_constructed(view);
+  copy_constructed.set(1);
+  EXPECT_EQ(view.get(), 1);
+  EXPECT_EQ(c.value, 1);
+
+  protocol_view<A> move_constructed(std::move(copy_constructed));
+  move_constructed.set(2);
+  EXPECT_EQ(view.get(), 2);
+  EXPECT_EQ(c.value, 2);
+
+  Conforming other;
+  protocol_view<A> other_view(other);
+  other_view = view;
+  other_view.set(3);
+  EXPECT_EQ(view.get(), 3);
+  EXPECT_EQ(c.value, 3);
+  EXPECT_EQ(other.value, 0);
+
+  Conforming yet_another;
+  protocol_view<A> yet_another_view(yet_another);
+  yet_another_view = std::move(other_view);
+  yet_another_view.set(4);
+  EXPECT_EQ(view.get(), 4);
+  EXPECT_EQ(c.value, 4);
+  EXPECT_EQ(yet_another.value, 0);
+}
+
+TEST(ReflectionProtocolTest, CopiesAreIndependentObjects) {
+  struct A {
+    int get() const;
+    void set(int);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void set(int new_value) { value = new_value; }
+  };
+
+  protocol<A> original(Conforming{});
+  original.set(1);
+
+  protocol<A> copy_constructed(original);
+  copy_constructed.set(2);
+  EXPECT_EQ(original.get(), 1);
+  EXPECT_EQ(copy_constructed.get(), 2);
+
+  protocol<A> move_constructed(std::move(copy_constructed));
+  EXPECT_TRUE(copy_constructed.valueless_after_move());
+  EXPECT_EQ(move_constructed.get(), 2);
+
+  protocol<A> copy_assigned(Conforming{});
+  copy_assigned = original;
+  copy_assigned.set(3);
+  EXPECT_EQ(original.get(), 1);
+  EXPECT_EQ(copy_assigned.get(), 3);
+
+  protocol<A> move_assigned(Conforming{});
+  move_assigned = std::move(copy_assigned);
+  EXPECT_EQ(move_assigned.get(), 3);
+  EXPECT_TRUE(copy_assigned.valueless_after_move());
+}
+
 // ---------------------------------------------------------------------------
 // Conformance check tests.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements @RyanJK5's suggestion from #202, replacing #212.

A copied or standalone `method_thunk` is undefined behaviour to call. The thunk's six special member functions are now `= default` but private, with the enclosing generated base as a friend, so `auto f = view.foo;` and `decltype(view.foo) f{};` are ill-formed while `protocol_view` keeps its defaulted special member functions and remains trivially copyable.

Closes #202.
