### PR TITLE
Bump astral-sh/setup-uv from v6 to v10.0.1

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -92,7 +92,7 @@ jobs:
           sudo ln -s /usr/bin/clang++-${{ env.COMPILER_VERSION }} /usr/bin/clang++
           sudo ln -s /usr/bin/clang-tidy-${{ env.COMPILER_VERSION }} /usr/bin/clang-tidy
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: "3.12"
       - name: Set up Python

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -312,7 +312,7 @@ jobs:
           echo "CXX=${{ matrix.settings.compiler.cxx }}" >> "$GITHUB_ENV"
           echo "CC=${{ matrix.settings.compiler.cc }}" >> "$GITHUB_ENV"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python
         run: uv sync
       - name: Run CMake

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,7 +24,7 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v6
+              uses: astral-sh/setup-uv@v10.0.1
 
             - name: Install Python dependencies
               run: uv sync

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -67,7 +67,7 @@ jobs:
           cmake --build build
           sudo cmake --install build
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: "3.12"
       - name: Set up Python

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -45,7 +45,7 @@ jobs:
           version: ${{ matrix.clang_version }}
           platform: x64
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python
         run: uv sync
       - name: Run CMake

--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 


### PR DESCRIPTION
Removes the Node.js 20 deprecation warning in CI (setup-uv v7+ runs on node24).

Pinned to an exact tag because v8+ no longer publishes floating major tags. The other breaking changes (`server-url` removal, `prune-cache` default, cache disabled on `pull_request_target`/`workflow_run`/`release`) do not affect these workflows.