### PR TITLE
Support overloaded member functions in the reflection implementation

### DIFF
--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -27,17 +27,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // `protocol_view`'s with destroy/copy/move entries used for allocator-aware
 // ownership.
 //
-// Neither implementation currently supports overloaded member functions or
-// operators.
+// Neither implementation currently supports operators.
 
 #include <algorithm>
 #include <cassert>
+#include <charconv>
 #include <concepts>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <meta>
 #include <ranges>
+#include <span>
+#include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -70,41 +74,43 @@ inline constexpr bool is_protocol_view_v = is_protocol_view<T>::value;
 
 namespace detail {
 
-// Returns `true` if the `candidate` member function is consistent with the
-// `interface` member function for the purposes of structural subtyping;
-// otherwise returns `false`.
-consteval bool member_function_conforms_to(std::meta::info candidate,
-                                           std::meta::info interface) {
+// Returns `true` if the member functions `candidate` and `interface` have
+// the same name, reference qualifiers, de-aliased return type and de-aliased
+// parameter types; const and noexcept are not compared.
+consteval bool same_signature_ignoring_const(std::meta::info candidate,
+                                             std::meta::info interface) {
   if (!has_identifier(interface) || !has_identifier(candidate)) return false;
   if (identifier_of(interface) != identifier_of(candidate)) return false;
-  // If interface is `const`, `candidate` must be const.
-  if (is_const(interface) != is_const(candidate)) return false;
-  // If interface is `noexcept`, `candidate` must be noexcept.
-  if (is_noexcept(interface) && !is_noexcept(candidate)) return false;
-  // Reference qualifiers must match.
   if (is_lvalue_reference_qualified(interface) !=
       is_lvalue_reference_qualified(candidate))
     return false;
   if (is_rvalue_reference_qualified(interface) !=
       is_rvalue_reference_qualified(candidate))
     return false;
-  // De-aliased return types must match.
   if (dealias(return_type_of(interface)) != dealias(return_type_of(candidate)))
     return false;
-  std::vector<std::meta::info> interface_params = parameters_of(interface);
-  std::vector<std::meta::info> candidate_params = parameters_of(candidate);
-  // Parameter counts must match.
-  if (interface_params.size() != candidate_params.size()) return false;
-  for (std::size_t i = 0; i < interface_params.size(); ++i) {
-    // De-aliased parameter types must match.
-    if (dealias(type_of(interface_params[i])) !=
-        dealias(type_of(candidate_params[i])))
-      return false;
-  }
-  return true;
+  auto dealiased_type_of = [](std::meta::info parameter) {
+    return dealias(type_of(parameter));
+  };
+  return std::ranges::equal(parameters_of(interface), parameters_of(candidate),
+                            {}, dealiased_type_of, dealiased_type_of);
 }
 
-// The named, non-static, non-special member functions of `Type`.
+// Returns `true` if the `candidate` member function is consistent with the
+// `interface` member function for the purposes of structural subtyping;
+// otherwise returns `false`.
+consteval bool member_function_conforms_to(std::meta::info candidate,
+                                           std::meta::info interface) {
+  if (!same_signature_ignoring_const(candidate, interface)) return false;
+  // If interface is `const`, `candidate` must be const.
+  if (is_const(interface) != is_const(candidate)) return false;
+  // If interface is `noexcept`, `candidate` must be noexcept.
+  return !is_noexcept(interface) || is_noexcept(candidate);
+}
+
+// The named, non-static, non-special member functions of `Type`, in
+// declaration order. Overloads appear as separate entries; an entry's index
+// identifies its vtable slot.
 //
 // TODO(jbcoe): Handle static functions as they can be used to satisfy
 // interface conformance.
@@ -116,41 +122,33 @@ constexpr inline auto protocol_interface_functions_of =
         std::views::filter(std::not_fn(std::meta::is_static_member)) |
         std::views::filter(std::meta::has_identifier));
 
-// Finds the vtable_generator<T>::vtable data member with the same name as
-// `Member`. vtable_generator and generate_wrapper_bases enumerate the same
-// interface members using the same identifier, so a match always exists.
-// `VtableType`/`Member` are template parameters for the same reason as
-// protocol_interface_functions_of's `Type`.
-template <std::meta::info VtableType, std::meta::info Member>
-consteval std::meta::info find_vtable_member() {
-  std::string_view target_name = identifier_of(Member);
-  for (std::meta::info m :
-       members_of(VtableType, std::meta::access_context::unprivileged())) {
-    if (has_identifier(m) && identifier_of(m) == target_name) return m;
-  }
-  std::unreachable();
+// The vtable entry for the interface member function at `Index`;
+// `generate_vtable_specs` declares one entry per interface member function in
+// the same order as `protocol_interface_functions_of`.
+template <std::meta::info VtableType, std::size_t Index>
+consteval std::meta::info vtable_entry_at() {
+  return nonstatic_data_members_of(
+      VtableType, std::meta::access_context::unprivileged())[Index];
 }
 
-// Vanishing-this-pointer thunk for a synthesised member function.
+// Vanishing-this-pointer thunk for one overload of a synthesised member
+// function.
 //
 // The thunk carries a single operator() whose signature mirrors one method
-// of the Interface type.
+// of the Interface type. `member_thunk` combines the thunks for all
+// overloads of a name into one overload set.
 template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
-          typename Vtable, std::meta::info Member, bool IsConst,
-          bool IsNoexcept>
+          typename Vtable, std::size_t Index, bool IsConst, bool IsNoexcept>
 struct method_thunk;
 
 // TODO(jbcoe): Extend this approach to handle lvalue and rvalue qualifiers.
 template <typename R, typename... Args, typename EnclosingType,
-          typename ProtocolType, typename Vtable, std::meta::info Member,
+          typename ProtocolType, typename Vtable, std::size_t Index,
           bool IsConst, bool IsNoexcept>
-struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Member,
+struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Index,
                     IsConst, IsNoexcept> {
-  // static consteval std::meta::info vtable_entry() {
-  //   return find_vtable_member<^^Vtable, Member>();
-  // }
   static constexpr std::meta::info vtable_entry =
-      find_vtable_member<^^Vtable, Member>();
+      vtable_entry_at<^^Vtable, Index>();
 
   // Provides member-function call syntax. Recovers the EnclosingType pointer
   // through the vanishing-this-pointer cast, widens it to the enclosing
@@ -178,8 +176,8 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Member,
                              std::forward<Args>(args)...);
   }
 
- private:
-  friend EnclosingType;
+ protected:
+  // Only `member_thunk` may create or copy a thunk.
   method_thunk() = default;
   ~method_thunk() = default;
   method_thunk(const method_thunk&) = default;
@@ -190,6 +188,64 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Member,
 
 template <bool Noexcept, typename R, typename... Args>
 using fn_ptr_t = R (*)(Args...) noexcept(Noexcept);
+
+// One overload of a synthesised member function: the interface member, its
+// vtable slot and the const-qualification of the generated wrapper.
+template <std::meta::info Member, std::size_t Index, bool IsConst>
+struct overload_spec {};
+
+// The `method_thunk` specialisation for an `overload_spec`.
+template <typename Spec, typename EnclosingType, typename ProtocolType,
+          typename Vtable>
+struct method_thunk_for;
+
+template <std::meta::info Member, std::size_t Index, bool IsConst,
+          typename EnclosingType, typename ProtocolType, typename Vtable>
+struct method_thunk_for<overload_spec<Member, Index, IsConst>, EnclosingType,
+                        ProtocolType, Vtable> {
+  // Build the function-pointer type R(*)(Args...) from the method's return
+  // type and parameter types.
+  static consteval std::meta::info fn_ptr_type() {
+    std::vector<std::meta::info> fn_args{std::meta::reflect_constant(false),
+                                         dealias(return_type_of(Member))};
+    fn_args.append_range(parameters_of(Member) |
+                         std::views::transform(std::meta::type_of));
+    return substitute(^^fn_ptr_t, fn_args);
+  }
+
+  // clang-format off
+  using type = typename[:substitute(
+      ^^method_thunk, {fn_ptr_type(), ^^EnclosingType, ^^ProtocolType, ^^Vtable,
+                       std::meta::reflect_constant(Index),
+                       std::meta::reflect_constant(IsConst),
+                       std::meta::reflect_constant(is_noexcept(Member))}):];
+  // clang-format on
+};
+
+template <typename Spec, typename EnclosingType, typename ProtocolType,
+          typename Vtable>
+using method_thunk_t =
+    method_thunk_for<Spec, EnclosingType, ProtocolType, Vtable>::type;
+
+// The overload set for one synthesised member function: a `method_thunk` per
+// overload, with every operator() brought into scope so that overload
+// resolution among them works as for a member function of the interface.
+template <typename EnclosingType, typename ProtocolType, typename Vtable,
+          typename... Specs>
+struct member_thunk
+    : method_thunk_t<Specs, EnclosingType, ProtocolType, Vtable>... {
+  using method_thunk_t<Specs, EnclosingType, ProtocolType,
+                       Vtable>::operator()...;
+
+ private:
+  friend EnclosingType;
+  member_thunk() = default;
+  ~member_thunk() = default;
+  member_thunk(const member_thunk&) = default;
+  member_thunk(member_thunk&&) = default;
+  member_thunk& operator=(const member_thunk&) = default;
+  member_thunk& operator=(member_thunk&&) = default;
+};
 
 // How generated wrappers treat the const-qualification of interface members.
 enum class const_policy {
@@ -203,43 +259,46 @@ enum class const_policy {
   const_only,
 };
 
-// TODO(jbcoe): Overloaded member functions are not yet supported. When they
-// are, a const/non-const overload pair `R f() const; R f();` in `I` should
-// resolve as it would through a reference: `protocol_view<I>` dispatches to
-// `R f()` (behind a const wrapper) and `protocol_view<const I>` to
-// `R f() const`.
+// Returns `true` if `ConstPolicy` generates a wrapper for `member`.
+//
+// Under `all_const` every wrapper is const, so a const/non-const overload
+// pair `R f() const; R f();` would collide; the const overload is dropped as
+// a non-const reference to `I` would also resolve `f()` to `R f()`.
+template <const_policy ConstPolicy>
+consteval bool generates_wrapper_for(std::meta::info member,
+                                     std::span<const std::meta::info> members) {
+  switch (ConstPolicy) {
+    case const_policy::propagate:
+      return true;
+    case const_policy::const_only:
+      return is_const(member);
+    case const_policy::all_const:
+      return !is_const(member) ||
+             std::ranges::none_of(members, [&](std::meta::info other) {
+               return !is_const(other) &&
+                      same_signature_ignoring_const(other, member);
+             });
+  }
+  std::unreachable();
+}
 
-// A single-member base wrapping the thunk for one interface member function,
-// named after that method (giving the `p.method_name(args)` call syntax).
-// `IsConst` selects the const-qualification of the generated wrapper, which
-// may differ from that of `Member` (see `const_policy`).
+// A single-member base wrapping the overload set for one interface member
+// function name, named after that method (giving the `p.method_name(args)`
+// call syntax). `Member` is the first overload and supplies the name; `Specs`
+// are the `overload_spec`s of the overloads exposed by the `const_policy`.
 template <std::meta::info Member, typename ProtocolType, typename Vtable,
-          bool IsConst>
+          typename... Specs>
 struct member_base_generator {
   struct member_base;
   consteval {
-    std::string_view name = identifier_of(Member);
-
-    // Build the function-pointer type R(*)(Args...) from the method's
-    // return type and parameter types.
-    std::vector<std::meta::info> fn_args{std::meta::reflect_constant(false),
-                                         dealias(return_type_of(Member))};
-    std::vector<std::meta::info> member_parameters = parameters_of(Member);
-    fn_args.append_range(member_parameters |
-                         std::views::transform(std::meta::type_of));
-    std::meta::info fn_ptr_type = substitute(^^fn_ptr_t, fn_args);
-
     // clang-format off
     std::meta::info thunk_type = substitute(
-        ^^method_thunk, {fn_ptr_type, ^^member_base, ^^ProtocolType, ^^Vtable,
-                       std::meta::reflect_constant(Member),
-                       std::meta::reflect_constant(IsConst),
-                       std::meta::reflect_constant(is_noexcept(Member))});
+        ^^member_thunk, {^^member_base, ^^ProtocolType, ^^Vtable, ^^Specs...});
 
     define_aggregate(
       ^^member_base, {data_member_spec(thunk_type,
                              std::meta::data_member_options{
-                              .name = name,
+                              .name = identifier_of(Member),
                               .no_unique_address = true
                             })});
     // clang-format on
@@ -247,9 +306,9 @@ struct member_base_generator {
 };
 
 template <std::meta::info Member, typename ProtocolType, typename Vtable,
-          bool IsConst>
+          typename... Specs>
 using member_base_generator_t =
-    member_base_generator<Member, ProtocolType, Vtable, IsConst>::member_base;
+    member_base_generator<Member, ProtocolType, Vtable, Specs...>::member_base;
 
 // Combines the single-member base types produced by `member_base_generator`
 // into one type via multiple inheritance.
@@ -257,30 +316,42 @@ template <typename... MemberBases>
 struct wrapper_bases : MemberBases... {};
 
 // Returns a `wrapper_bases` specialisation with one base per public,
-// non-special, member function of `interface_type` selected by `ConstPolicy`,
-// giving named members with `operator()` for each.
-//
-// Two bases defining a member of the same name make that name ambiguous to
-// look up through the derived class, so overloaded methods are unsupported
-// for now.
+// non-special, member function name of `interface_type`, giving named members
+// with an `operator()` for each overload selected by `ConstPolicy`.
 template <std::meta::info InterfaceType, typename ProtocolType, typename Vtable,
           const_policy ConstPolicy>
 consteval std::meta::info generate_wrapper_bases() {
+  std::span<const std::meta::info> members =
+      protocol_interface_functions_of<InterfaceType>;
   std::vector<std::meta::info> member_base_types;
-  for (std::meta::info member :
-       protocol_interface_functions_of<InterfaceType>) {
-    if (ConstPolicy == const_policy::const_only && !is_const(member)) {
-      continue;
+  std::vector<std::string_view> names_generated;
+  for (std::meta::info first : members) {
+    std::string_view name = identifier_of(first);
+    if (std::ranges::contains(names_generated, name)) continue;
+    names_generated.push_back(name);
+
+    std::vector<std::meta::info> specs;
+    for (std::size_t index = 0; index < members.size(); ++index) {
+      std::meta::info member = members[index];
+      if (identifier_of(member) != name ||
+          !generates_wrapper_for<ConstPolicy>(member, members))
+        continue;
+      const bool wrapper_is_const =
+          ConstPolicy == const_policy::propagate ? is_const(member) : true;
+      // clang-format off
+      specs.push_back(substitute(
+          ^^overload_spec, {reflect_constant(member),
+                            std::meta::reflect_constant(index),
+                            std::meta::reflect_constant(wrapper_is_const)}));
+      // clang-format on
     }
-    const bool wrapper_is_const =
-        ConstPolicy == const_policy::propagate ? is_const(member) : true;
-    // clang-format off
-    member_base_types.push_back(dealias(
-        substitute(^^member_base_generator_t,
-                   {reflect_constant(member), ^^ProtocolType, ^^Vtable,
-                    std::meta::reflect_constant(wrapper_is_const)}))
-      );
-    // clang-format on
+    if (specs.empty()) continue;
+
+    std::vector<std::meta::info> generator_args{reflect_constant(first),
+                                                ^^ProtocolType, ^^Vtable};
+    generator_args.append_range(specs);
+    member_base_types.push_back(
+        dealias(substitute(^^member_base_generator_t, generator_args)));
   }
   return substitute(^^wrapper_bases, member_base_types);
 }
@@ -294,21 +365,30 @@ using protocol_wrappers_t =
     typename[:generate_wrapper_bases<^^T, ProtocolType, Vtable,
                                      ConstPolicy>():];
 
+// Names the vtable entry for the interface member function at `index`.
+// Overloads share an identifier, so the index keeps entry names unique.
+consteval std::string vtable_entry_name(std::meta::info member,
+                                        std::size_t index) {
+  char digits[std::numeric_limits<std::size_t>::digits10 + 1];
+  auto [end, error] = std::to_chars(digits, digits + sizeof(digits), index);
+  std::string name(identifier_of(member));
+  name += '_';
+  name.append(digits, end);
+  return name;
+}
+
 // Returns a list of data_member_spec values, one for each member function
 // implemented by `protocol`, each describing a vtable function pointer with
 // signature R(*)(void*, Args...) for a mutable interface method, or
 // R(*)(const void*, Args...) for a const one.
-//
-// Because C++ disallows two data members with the same name inside the same
-// class, overloaded methods will cause compile-time errors.
-// We will address this limitation in a follow-up PR.
 template <std::meta::info interface_type>
 consteval std::vector<std::meta::info> generate_vtable_specs() {
   std::vector<std::meta::info> function_pointer_specs;
 
-  for (std::meta::info member :
-       protocol_interface_functions_of<interface_type>) {
-    std::string_view name = identifier_of(member);
+  std::span<const std::meta::info> members =
+      protocol_interface_functions_of<interface_type>;
+  for (std::size_t index = 0; index < members.size(); ++index) {
+    std::meta::info member = members[index];
 
     // Build the function-pointer type R(*)(void*, Args...) noexcept(...)
     // from the method's return type, parameter types and noexcept-ness; a
@@ -325,7 +405,8 @@ consteval std::vector<std::meta::info> generate_vtable_specs() {
     std::meta::info fn_ptr_type = substitute(^^fn_ptr_t, fn_args);
 
     function_pointer_specs.push_back(data_member_spec(
-        fn_ptr_type, std::meta::data_member_options{.name = name}));
+        fn_ptr_type, std::meta::data_member_options{
+                         .name = vtable_entry_name(member, index)}));
   }
   return function_pointer_specs;
 }
@@ -394,10 +475,13 @@ consteval typename vtable_generator<T>::vtable make_view_vtable() {
   using Vtable = typename vtable_generator<T>::vtable;
   Vtable result{};
 
-  template for (constexpr std::meta::info member :
-                protocol_interface_functions_of<^^T>) {
+  constexpr std::span<const std::meta::info> members =
+      protocol_interface_functions_of<^^T>;
+  template for (constexpr std::size_t index :
+                std::views::iota(std::size_t{0}, members.size())) {
+    constexpr std::meta::info member = members[index];
     constexpr std::meta::info vtable_member =
-        find_vtable_member<^^Vtable, member>();
+        vtable_entry_at<^^Vtable, index>();
     using FnPtrType = typename[:type_of(vtable_member):];
     if constexpr (is_const(member)) {
       constexpr std::meta::info candidate =
@@ -570,8 +654,7 @@ class protocol
   // Grants the synthesised member thunks access to `object_`/`vtable_` so
   // they can locate and call through the matching vtable entry.
   template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
-            typename Vtable, std::meta::info Member, bool IsConst,
-            bool IsNoexcept>
+            typename Vtable, std::size_t Index, bool IsConst, bool IsNoexcept>
   friend struct detail::method_thunk;
 
   [[no_unique_address]] Alloc alloc_;
@@ -800,8 +883,7 @@ class protocol_view
   // Grants the synthesised member thunks access to `object_`/`vtable_` so
   // they can locate and call through the matching vtable entry.
   template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
-            typename Vtable, std::meta::info Member, bool IsConst,
-            bool IsNoexcept>
+            typename Vtable, std::size_t Index, bool IsConst, bool IsNoexcept>
   friend struct detail::method_thunk;
 
   // Non-owning pointer to the viewed object.
@@ -847,8 +929,7 @@ class protocol_view<const T> : public detail::protocol_wrappers_t<
   // Grants the synthesised member thunks access to `object_`/`vtable_` so
   // they can locate and call through the matching vtable entry.
   template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
-            typename Vtable, std::meta::info Member, bool IsConst,
-            bool IsNoexcept>
+            typename Vtable, std::size_t Index, bool IsConst, bool IsNoexcept>
   friend struct detail::method_thunk;
 
   // Non-owning pointer to the viewed object.

--- a/reflection/protocol_test.cc
+++ b/reflection/protocol_test.cc
@@ -1053,10 +1053,32 @@ TEST(ReflectionProtocolViewTest, MemberThunksCannotBeDetachedForOverloads) {
   static_assert(!std::is_default_constructible_v<decltype(p.compute)>);
   static_assert(!std::is_destructible_v<decltype(p.compute)>);
   static_assert(std::is_trivially_copyable_v<decltype(p.compute)>);
+}
 
+TEST(ReflectionProtocolViewTest, OverloadsThroughThunkReference) {
+  struct Interface {
+    int compute(int x);
+    double compute(double x);
+    std::string compute(const std::string& x) const;
+  };
+
+  struct Conforming {
+    int compute(int x) { return x * 2; }
+
+    double compute(double x) { return x * 3.0; }
+
+    std::string compute(const std::string& x) const { return x + x; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> p(c);
+
+  // `protocol_view` is shallow const: the non-const overloads are callable
+  // through a const reference to the thunk.
   const auto& compute = p.compute;
   EXPECT_EQ(compute(5), 10);
   EXPECT_EQ(compute(5.0), 15.0);
+  EXPECT_EQ(compute(std::string("A")), "AA");
 }
 
 // Member function forwarding tests for protocol.
@@ -1491,6 +1513,24 @@ TEST(ReflectionProtocolTest, MemberThunksCannotBeDetachedForOverloads) {
   static_assert(!std::is_default_constructible_v<decltype(p.compute)>);
   static_assert(!std::is_destructible_v<decltype(p.compute)>);
   static_assert(std::is_trivially_copyable_v<decltype(p.compute)>);
+}
+
+TEST(ReflectionProtocolTest, OverloadsThroughThunkReference) {
+  struct Interface {
+    int compute(int x);
+    double compute(double x);
+    std::string compute(const std::string& x) const;
+  };
+
+  struct Conforming {
+    int compute(int x) { return x * 2; }
+
+    double compute(double x) { return x * 3.0; }
+
+    std::string compute(const std::string& x) const { return x + x; }
+  };
+
+  protocol<Interface> p(Conforming{});
 
   // Const propagates through `protocol`: the non-const overloads need a
   // non-const reference to the thunk.

--- a/reflection/protocol_test.cc
+++ b/reflection/protocol_test.cc
@@ -31,6 +31,13 @@ concept has_update = requires(P& p) { p.update(0); };
 template <typename P>
 concept has_get_value = requires(P& p) { p.get_value(); };
 
+// Concepts for overloaded `get`/`get(int)` negative tests.
+template <typename P>
+concept has_get_int = requires(P& p) { p.get(0); };
+
+template <typename P>
+concept has_get = requires(P& p) { p.get(); };
+
 // ---------------------------------------------------------------------------
 // Type trait tests.
 // ---------------------------------------------------------------------------
@@ -534,6 +541,93 @@ TEST(ConformsToTest, UnqualifiedInterfaceDoesNotMatchRefQualifiedCandidate) {
   static_assert(!is_protocol_conformant<Interface, RvalueRefCandidate>());
 }
 
+TEST(ConformsToTest, OverloadedMemberFunctionsConform) {
+  struct Interface {
+    int compute(int value);
+    double compute(double value);
+    std::string compute(const std::string& value) const;
+  };
+
+  struct Conforming {
+    int compute(int value) { return value; }
+
+    double compute(double value) { return value; }
+
+    std::string compute(const std::string& value) const { return value; }
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+}
+
+TEST(ConformsToTest, CandidateMissingOverloadDoesNotConform) {
+  struct Interface {
+    int compute(int value);
+    double compute(double value);
+    std::string compute(const std::string& value) const;
+  };
+
+  struct MissingOverloads {
+    int compute(int value) { return value; }
+  };
+
+  static_assert(!is_protocol_conformant<Interface, MissingOverloads>());
+}
+
+TEST(ConformsToTest, CandidateWithExtraOverloadsConforms) {
+  struct Interface {
+    int compute(int value);
+  };
+
+  struct CandidateWithExtraOverload {
+    int compute(int value) { return value; }
+
+    double compute(double value) { return value; }
+  };
+
+  static_assert(
+      is_protocol_conformant<Interface, CandidateWithExtraOverload>());
+}
+
+TEST(ConformsToTest, OverloadsByArityConform) {
+  struct Interface {
+    int f(int a);
+    int f(int a, int b);
+  };
+
+  struct Conforming {
+    int f(int a) { return a; }
+
+    int f(int a, int b) { return a + b; }
+  };
+
+  struct MissingUnaryOverload {
+    int f(int a, int b) { return a + b; }
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+  static_assert(!is_protocol_conformant<Interface, MissingUnaryOverload>());
+}
+
+TEST(ConformsToTest, ConstAndNonConstOverloadPairConforms) {
+  struct Interface {
+    int f() const;
+    int f();
+  };
+
+  struct Conforming {
+    int f() const { return 1; }
+
+    int f() { return 2; }
+  };
+
+  struct ConstOnly {
+    int f() const { return 1; }
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+  static_assert(!is_protocol_conformant<Interface, ConstOnly>());
+}
+
 // ---------------------------------------------------------------------------
 // Constructability tests.
 // ---------------------------------------------------------------------------
@@ -839,6 +933,130 @@ TEST(ReflectionProtocolViewTest, MixedConstAndMutatingMemberFunctions) {
   p.set(7);
   EXPECT_EQ(p.get(), 7);
   EXPECT_EQ(c.value, 7);
+}
+
+TEST(ReflectionProtocolViewTest, OverloadsByParameterType) {
+  struct Interface {
+    int compute(int x);
+    double compute(double x);
+    std::string compute(const std::string& x) const;
+  };
+
+  struct Conforming {
+    int compute(int x) { return x * 2; }
+
+    double compute(double x) { return x * 3.0; }
+
+    std::string compute(const std::string& x) const { return x + x; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> p(c);
+  EXPECT_EQ(p.compute(5), 10);
+  EXPECT_EQ(p.compute(5.0), 15.0);
+  EXPECT_EQ(p.compute(std::string("A")), "AA");
+}
+
+TEST(ReflectionProtocolViewTest,
+     ConstAndNonConstOverloadPairDispatchesToNonConst) {
+  struct Interface {
+    int value() const;
+    int value();
+  };
+
+  struct Conforming {
+    int value() const { return 1; }
+
+    int value() { return 2; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> view(c);
+  EXPECT_EQ(view.value(), 2);
+
+  // Shallow const: a const protocol_view still dispatches to the non-const
+  // overload.
+  const protocol_view<Interface>& const_view = view;
+  EXPECT_EQ(const_view.value(), 2);
+}
+
+TEST(ReflectionProtocolViewTest, ConstViewDispatchesToConstOverload) {
+  struct Interface {
+    int value() const;
+    int value();
+  };
+
+  struct Conforming {
+    int value() const { return 1; }
+
+    int value() { return 2; }
+  };
+
+  Conforming c;
+  protocol_view<const Interface> view(c);
+  EXPECT_EQ(view.value(), 1);
+
+  const Conforming const_c;
+  protocol_view<const Interface> const_view(const_c);
+  EXPECT_EQ(const_view.value(), 1);
+}
+
+TEST(ReflectionProtocolViewTest, ConstViewExposesOnlyConstOverloads) {
+  struct Interface {
+    int get() const;
+    void get(int value);
+  };
+
+  static_assert(!has_get_int<protocol_view<const Interface>>);
+  static_assert(has_get_int<protocol_view<Interface>>);
+  static_assert(has_get_int<const protocol_view<Interface>>);
+
+  static_assert(has_get<protocol_view<const Interface>>);
+  static_assert(has_get<protocol_view<Interface>>);
+  static_assert(has_get<const protocol_view<Interface>>);
+}
+
+TEST(ReflectionProtocolViewTest, IsTriviallyCopyableWithOverloads) {
+  struct Interface {
+    int compute(int x);
+    double compute(double x);
+    std::string compute(const std::string& x) const;
+  };
+
+  static_assert(std::is_trivially_copyable_v<protocol_view<Interface>>);
+  static_assert(std::is_trivially_copyable_v<protocol_view<const Interface>>);
+  static_assert(sizeof(protocol_view<Interface>) == 2 * sizeof(void*));
+}
+
+TEST(ReflectionProtocolViewTest, MemberThunksCannotBeDetachedForOverloads) {
+  struct Interface {
+    int compute(int x);
+    double compute(double x);
+    std::string compute(const std::string& x) const;
+  };
+
+  struct Conforming {
+    int compute(int x) { return x * 2; }
+
+    double compute(double x) { return x * 3.0; }
+
+    std::string compute(const std::string& x) const { return x + x; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> p(c);
+
+  static_assert(!std::is_copy_constructible_v<decltype(p.compute)>);
+  static_assert(!std::is_move_constructible_v<decltype(p.compute)>);
+  static_assert(!std::is_copy_assignable_v<decltype(p.compute)>);
+  static_assert(!std::is_move_assignable_v<decltype(p.compute)>);
+  static_assert(!std::is_default_constructible_v<decltype(p.compute)>);
+  static_assert(!std::is_destructible_v<decltype(p.compute)>);
+  static_assert(std::is_trivially_copyable_v<decltype(p.compute)>);
+
+  const auto& compute = p.compute;
+  EXPECT_EQ(compute(5), 10);
+  EXPECT_EQ(compute(5.0), 15.0);
 }
 
 // Member function forwarding tests for protocol.
@@ -1175,5 +1393,130 @@ TEST(ReflectionProtocolTest, ConstMemberFunctionOnConstProtocol) {
   // A non-const member function is still not invocable on a const protocol;
   // that assertion is already covered above by
   // NonConstMemberFunctionNotInvocableFromConst.
+}
+
+TEST(ReflectionProtocolTest, OverloadsByParameterType) {
+  struct Interface {
+    int compute(int x);
+    double compute(double x);
+    std::string compute(const std::string& x) const;
+  };
+
+  struct Conforming {
+    int compute(int x) { return x * 2; }
+
+    double compute(double x) { return x * 3.0; }
+
+    std::string compute(const std::string& x) const { return x + x; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.compute(5), 10);
+  EXPECT_EQ(p.compute(5.0), 15.0);
+
+  const auto& const_p = p;
+  EXPECT_EQ(const_p.compute(std::string("A")), "AA");
+}
+
+TEST(ReflectionProtocolTest, OverloadsByArity) {
+  struct Interface {
+    int add(int a);
+    int add(int a, int b);
+  };
+
+  struct Conforming {
+    int add(int a) { return a; }
+
+    int add(int a, int b) { return a + b; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.add(1), 1);
+  EXPECT_EQ(p.add(1, 2), 3);
+}
+
+TEST(ReflectionProtocolTest, ConstAndNonConstOverloadPair) {
+  struct Interface {
+    int value() const;
+    int value();
+  };
+
+  struct Conforming {
+    int value() const { return 1; }
+
+    int value() { return 2; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.value(), 2);
+
+  const protocol<Interface>& const_p = p;
+  EXPECT_EQ(const_p.value(), 1);
+}
+
+TEST(ReflectionProtocolTest, ConstProtocolExposesOnlyConstOverloads) {
+  struct Interface {
+    int get() const;
+    void get(int value);
+  };
+
+  static_assert(!has_get_int<const protocol<Interface>>);
+  static_assert(has_get_int<protocol<Interface>>);
+
+  static_assert(has_get<protocol<Interface>>);
+  static_assert(has_get<const protocol<Interface>>);
+}
+
+TEST(ReflectionProtocolTest, MemberThunksCannotBeDetachedForOverloads) {
+  struct Interface {
+    int compute(int x);
+    double compute(double x);
+    std::string compute(const std::string& x) const;
+  };
+
+  struct Conforming {
+    int compute(int x) { return x * 2; }
+
+    double compute(double x) { return x * 3.0; }
+
+    std::string compute(const std::string& x) const { return x + x; }
+  };
+
+  protocol<Interface> p(Conforming{});
+
+  static_assert(!std::is_copy_constructible_v<decltype(p.compute)>);
+  static_assert(!std::is_move_constructible_v<decltype(p.compute)>);
+  static_assert(!std::is_copy_assignable_v<decltype(p.compute)>);
+  static_assert(!std::is_move_assignable_v<decltype(p.compute)>);
+  static_assert(!std::is_default_constructible_v<decltype(p.compute)>);
+  static_assert(!std::is_destructible_v<decltype(p.compute)>);
+  static_assert(std::is_trivially_copyable_v<decltype(p.compute)>);
+
+  // Const propagates through `protocol`: the non-const overloads need a
+  // non-const reference to the thunk.
+  auto& compute = p.compute;
+  EXPECT_EQ(compute(5), 10);
+  EXPECT_EQ(compute(5.0), 15.0);
+  const auto& const_compute = p.compute;
+  EXPECT_EQ(const_compute(std::string("A")), "AA");
+}
+
+TEST(ReflectionProtocolTest, NoexceptOverload) {
+  struct Interface {
+    int f(int x) noexcept;
+    int f(double x);
+  };
+
+  struct Conforming {
+    int f(int x) noexcept { return x * 2; }
+
+    int f(double x) { return static_cast<int>(x * 3.0); }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p.f(5), 10);
+  EXPECT_EQ(p.f(5.0), 15);
+  static_assert(noexcept(p.f(1)));
+  static_assert(!noexcept(p.f(1.0)));
 }
 }  // namespace


### PR DESCRIPTION
Closes #209.

- Interface member functions are grouped by name; each name gets one `member_thunk` deriving from a `method_thunk` per overload, with `using ...::operator()...` forming the overload set.
- Vtable entries are addressed by index (named `<identifier>_<index>`), so overloads get distinct slots.
- `protocol_view<I>` (shallow const): for a pair `R f() const; R f();` the const overload is dropped so `f()` resolves to `R f()`, as through `I&`. `protocol_view<const I>` keeps only the const overloads; `protocol<I>` propagates const as before.