### PR TITLE
Grant the codespace actions: write so failed CI jobs can be re-run with gh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,16 @@
 	"remoteUser": "vscode",
 	"mounts": [
 		"type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,readonly"
-	]
+	],
+	"customizations": {
+		"codespaces": {
+			"repositories": {
+				"jbcoe/cc-protocol": {
+					"permissions": {
+						"actions": "write"
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
`gh run rerun --failed` from a codespace fails with "Resource not accessible by integration": the Codespaces `GITHUB_TOKEN` has no `actions: write`. Declaring the permission in `devcontainer.json` makes GitHub request it when the codespace is created, so failed jobs (e.g. the transient apt failure on #228) can be re-run from the terminal.
