### PR TITLE
Support call operators in the reflection implementation

### DIFF
--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -153,7 +153,7 @@ consteval auto protocol_interface_function_infos() {
   std::vector<std::meta::info> result(std::ranges::begin(named),
                                       std::ranges::end(named));
   // Per [meta.reflection.member.queries], a closure type's function call
-  // operator is members-of-eligible, but GCC's `members_of` does not yet
+  // operator is members-of-eligible, but GCC16's `members_of` does not yet
   // enumerate it, leaving `result` empty for lambdas; name the operator
   // directly as a fallback.
   using T = typename[:Type:];

--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -27,7 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // `protocol_view`'s with destroy/copy/move entries used for allocator-aware
 // ownership.
 //
-// Neither implementation currently supports operators.
+// Neither implementation currently supports operators other than operator().
 
 #include <algorithm>
 #include <cassert>
@@ -74,13 +74,41 @@ inline constexpr bool is_protocol_view_v = is_protocol_view<T>::value;
 
 namespace detail {
 
+// Per ISO C++ ([expr.prim.lambda.closure]), closure types are unique, unnamed,
+// non-union class types.
+// This concept will also match an unnamed class type with a single
+// `operator()`.
+// TODO(jbcoe): Refine this concept to match only lambdas.
+template <typename T>
+concept is_maybe_lambda =
+    is_class_type(dealias(^^T)) && !has_identifier(dealias(^^T)) &&
+    requires { &T::operator(); };
+
+consteval bool is_call_operator(std::meta::info function) {
+  return is_operator_function(function) &&
+         operator_of(function) == std::meta::operators::op_parentheses;
+}
+
+// Returns `true` if `a` and `b` are both call operators or share an
+// identifier.
+consteval bool same_name(std::meta::info a, std::meta::info b) {
+  if (is_call_operator(a) || is_call_operator(b))
+    return is_call_operator(a) && is_call_operator(b);
+  return has_identifier(a) && has_identifier(b) &&
+         identifier_of(a) == identifier_of(b);
+}
+
+// A valid identifier for `member`, for naming generated vtable entries.
+consteval std::string_view member_name(std::meta::info member) {
+  return is_call_operator(member) ? "call_operator" : identifier_of(member);
+}
+
 // Returns `true` if the member functions `candidate` and `interface` have
 // the same name, reference qualifiers, de-aliased return type and de-aliased
 // parameter types; const and noexcept are not compared.
 consteval bool same_signature_ignoring_const(std::meta::info candidate,
                                              std::meta::info interface) {
-  if (!has_identifier(interface) || !has_identifier(candidate)) return false;
-  if (identifier_of(interface) != identifier_of(candidate)) return false;
+  if (!same_name(candidate, interface)) return false;
   if (is_lvalue_reference_qualified(interface) !=
       is_lvalue_reference_qualified(candidate))
     return false;
@@ -108,19 +136,36 @@ consteval bool member_function_conforms_to(std::meta::info candidate,
   return !is_noexcept(interface) || is_noexcept(candidate);
 }
 
-// The named, non-static, non-special member functions of `Type`, in
-// declaration order. Overloads appear as separate entries; an entry's index
-// identifies its vtable slot.
+// The named, non-static, non-special member functions and call operators of
+// `Type`, in declaration order. Overloads appear as separate entries; an
+// entry's index identifies its vtable slot.
 //
 // TODO(jbcoe): Handle static functions as they can be used to satisfy
 // interface conformance.
 template <std::meta::info Type>
+consteval auto protocol_interface_function_infos() {
+  auto named = members_of(Type, std::meta::access_context::unprivileged()) |
+               std::views::filter(std::meta::is_function) |
+               std::views::filter(std::not_fn(std::meta::is_static_member)) |
+               std::views::filter([](std::meta::info member) consteval {
+                 return has_identifier(member) || is_call_operator(member);
+               });
+  std::vector<std::meta::info> result(std::ranges::begin(named),
+                                      std::ranges::end(named));
+  // Per [meta.reflection.member.queries], a closure type's function call
+  // operator is members-of-eligible, but GCC's `members_of` does not yet
+  // enumerate it, leaving `result` empty for lambdas; name the operator
+  // directly as a fallback.
+  using T = typename[:Type:];
+  if constexpr (is_maybe_lambda<T>) {
+    if (result.empty()) result.push_back(^^T::operator());
+  }
+  return result;
+}
+
+template <std::meta::info Type>
 constexpr inline auto protocol_interface_functions_of =
-    std::define_static_array(
-        members_of(Type, std::meta::access_context::unprivileged()) |
-        std::views::filter(std::meta::is_function) |
-        std::views::filter(std::not_fn(std::meta::is_static_member)) |
-        std::views::filter(std::meta::has_identifier));
+    std::define_static_array(protocol_interface_function_infos<Type>());
 
 // The vtable entry for the interface member function at `Index`;
 // `generate_vtable_specs` declares one entry per interface member function in
@@ -150,15 +195,28 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Index,
   static constexpr std::meta::info vtable_entry =
       vtable_entry_at<^^Vtable, Index>();
 
-  // Provides member-function call syntax. Recovers the EnclosingType pointer
-  // through the vanishing-this-pointer cast, widens it to the enclosing
-  // protocol/protocol_view object, then calls through its stored vtable
-  // pointer's matching function pointer, passing the viewed/owned object.
+  // Recovers the EnclosingType pointer: `call_operator_base` derives from
+  // this thunk, while a generated `member_base` holds it as its sole data
+  // member (the vanishing-this-pointer cast).
+  template <typename Self>
+  static auto* enclosing(Self* self) {
+    using Enclosing = std::conditional_t<std::is_const_v<Self>,
+                                         const EnclosingType, EnclosingType>;
+    if constexpr (std::derived_from<EnclosingType, method_thunk>) {
+      return static_cast<Enclosing*>(self);
+    } else {
+      return reinterpret_cast<Enclosing*>(self);
+    }
+  }
+
+  // Provides member-function call syntax. Widens the EnclosingType pointer
+  // to the enclosing protocol/protocol_view object, then calls through its
+  // stored vtable pointer's matching function pointer, passing the
+  // viewed/owned object.
   R operator()(Args... args) noexcept(IsNoexcept)
     requires(!IsConst)
   {
-    auto* enclosing = reinterpret_cast<EnclosingType*>(this);
-    auto* protocol_object = static_cast<ProtocolType*>(enclosing);
+    auto* protocol_object = static_cast<ProtocolType*>(enclosing(this));
     const Vtable* vtable = protocol_object->vtable_;
     constexpr std::meta::info entry = vtable_entry;
     return vtable->[:entry:](protocol_object->object_,
@@ -168,8 +226,8 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Index,
   R operator()(Args... args) const noexcept(IsNoexcept)
     requires(IsConst)
   {
-    const auto* enclosing = reinterpret_cast<const EnclosingType*>(this);
-    const auto* protocol_object = static_cast<const ProtocolType*>(enclosing);
+    const auto* protocol_object =
+        static_cast<const ProtocolType*>(enclosing(this));
     const Vtable* vtable = protocol_object->vtable_;
     constexpr std::meta::info entry = vtable_entry;
     return vtable->[:entry:](protocol_object->object_,
@@ -247,6 +305,22 @@ struct member_thunk
   member_thunk& operator=(member_thunk&&) = default;
 };
 
+// The wrapper base for an interface's call operators. Deriving from the
+// overload set gives `p(args)` call syntax; protected special members let a
+// protocol/protocol_view copy the base but stop it being sliced off.
+template <typename ProtocolType, typename Vtable, typename... Specs>
+struct call_operator_base
+    : member_thunk<call_operator_base<ProtocolType, Vtable, Specs...>,
+                   ProtocolType, Vtable, Specs...> {
+ protected:
+  call_operator_base() = default;
+  ~call_operator_base() = default;
+  call_operator_base(const call_operator_base&) = default;
+  call_operator_base(call_operator_base&&) = default;
+  call_operator_base& operator=(const call_operator_base&) = default;
+  call_operator_base& operator=(call_operator_base&&) = default;
+};
+
 // How generated wrappers treat the const-qualification of interface members.
 enum class const_policy {
   // `protocol<I>`: as declared in `I`, so `const protocol<I>` exposes only the
@@ -317,23 +391,26 @@ struct wrapper_bases : MemberBases... {};
 
 // Returns a `wrapper_bases` specialisation with one base per public,
 // non-special, member function name of `interface_type`, giving named members
-// with an `operator()` for each overload selected by `ConstPolicy`.
+// with an `operator()` for each overload selected by `ConstPolicy`, plus a
+// `call_operator_base` if `interface_type` has call operators.
 template <std::meta::info InterfaceType, typename ProtocolType, typename Vtable,
           const_policy ConstPolicy>
 consteval std::meta::info generate_wrapper_bases() {
   std::span<const std::meta::info> members =
       protocol_interface_functions_of<InterfaceType>;
   std::vector<std::meta::info> member_base_types;
-  std::vector<std::string_view> names_generated;
+  std::vector<std::meta::info> names_generated;
   for (std::meta::info first : members) {
-    std::string_view name = identifier_of(first);
-    if (std::ranges::contains(names_generated, name)) continue;
-    names_generated.push_back(name);
+    if (std::ranges::any_of(names_generated, [&](std::meta::info generated) {
+          return same_name(first, generated);
+        }))
+      continue;
+    names_generated.push_back(first);
 
     std::vector<std::meta::info> specs;
     for (std::size_t index = 0; index < members.size(); ++index) {
       std::meta::info member = members[index];
-      if (identifier_of(member) != name ||
+      if (!same_name(member, first) ||
           !generates_wrapper_for<ConstPolicy>(member, members))
         continue;
       const bool wrapper_is_const =
@@ -347,11 +424,17 @@ consteval std::meta::info generate_wrapper_bases() {
     }
     if (specs.empty()) continue;
 
-    std::vector<std::meta::info> generator_args{reflect_constant(first),
-                                                ^^ProtocolType, ^^Vtable};
+    std::vector<std::meta::info> generator_args;
+    if (!is_call_operator(first)) {
+      generator_args.push_back(reflect_constant(first));
+    }
+    generator_args.push_back(^^ProtocolType);
+    generator_args.push_back(^^Vtable);
     generator_args.append_range(specs);
     member_base_types.push_back(
-        dealias(substitute(^^member_base_generator_t, generator_args)));
+        is_call_operator(first)
+            ? substitute(^^call_operator_base, generator_args)
+            : dealias(substitute(^^member_base_generator_t, generator_args)));
   }
   return substitute(^^wrapper_bases, member_base_types);
 }
@@ -371,7 +454,7 @@ consteval std::string vtable_entry_name(std::meta::info member,
                                         std::size_t index) {
   char digits[std::numeric_limits<std::size_t>::digits10 + 1];
   auto [end, error] = std::to_chars(digits, digits + sizeof(digits), index);
-  std::string name(identifier_of(member));
+  std::string name(member_name(member));
   name += '_';
   name.append(digits, end);
   return name;

--- a/reflection/protocol_test.cc
+++ b/reflection/protocol_test.cc
@@ -38,6 +38,13 @@ concept has_get_int = requires(P& p) { p.get(0); };
 template <typename P>
 concept has_get = requires(P& p) { p.get(); };
 
+// Concepts for call operator tests.
+template <typename P>
+concept is_callable = requires(P& p) { p(); };
+
+template <typename P>
+concept is_callable_with_int = requires(P& p) { p(0); };
+
 // ---------------------------------------------------------------------------
 // Type trait tests.
 // ---------------------------------------------------------------------------
@@ -628,6 +635,73 @@ TEST(ConformsToTest, ConstAndNonConstOverloadPairConforms) {
   static_assert(!is_protocol_conformant<Interface, ConstOnly>());
 }
 
+TEST(ConformsToTest, CallOperatorConforms) {
+  struct Interface {
+    int operator()(int x) const;
+  };
+
+  struct Conforming {
+    int operator()(int x) const { return x + 1; }
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+
+  auto lambda = [](int x) { return x + 1; };
+  static_assert(is_protocol_conformant<Interface, decltype(lambda)>());
+}
+
+TEST(ConformsToTest, CallOperatorWithWrongSignatureDoesNotConform) {
+  struct Interface {
+    int operator()(int x) const;
+  };
+
+  struct WrongParam {
+    int operator()(double x) const { return static_cast<int>(x); }
+  };
+
+  struct NonConst {
+    int operator()(int x) { return x; }
+  };
+
+  static_assert(!is_protocol_conformant<Interface, WrongParam>());
+  static_assert(!is_protocol_conformant<Interface, NonConst>());
+}
+
+TEST(ConformsToTest, MutableLambdaConformsToNonConstCallOperator) {
+  struct Interface {
+    int operator()(int x);
+  };
+
+  auto mutable_lambda = [](int x) mutable { return x + 1; };
+  auto const_lambda = [](int x) { return x + 1; };
+
+  static_assert(is_protocol_conformant<Interface, decltype(mutable_lambda)>());
+  static_assert(!is_protocol_conformant<Interface, decltype(const_lambda)>());
+}
+
+TEST(ConformsToTest, OverloadedCallOperatorsConform) {
+  struct Interface {
+    int operator()(int x);
+    double operator()(double x);
+    std::string operator()(const std::string& x) const;
+  };
+
+  struct Conforming {
+    int operator()(int x) { return x * 2; }
+
+    double operator()(double x) { return x * 3.0; }
+
+    std::string operator()(const std::string& x) const { return x + x; }
+  };
+
+  struct MissingOverloads {
+    int operator()(int x) { return x * 2; }
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+  static_assert(!is_protocol_conformant<Interface, MissingOverloads>());
+}
+
 // ---------------------------------------------------------------------------
 // Constructability tests.
 // ---------------------------------------------------------------------------
@@ -1079,6 +1153,145 @@ TEST(ReflectionProtocolViewTest, OverloadsThroughThunkReference) {
   EXPECT_EQ(compute(5), 10);
   EXPECT_EQ(compute(5.0), 15.0);
   EXPECT_EQ(compute(std::string("A")), "AA");
+}
+
+// Call operator tests for protocol_view.
+
+TEST(ReflectionProtocolViewTest, CallOperator) {
+  struct Interface {
+    int operator()(int x) const;
+  };
+
+  struct Conforming {
+    int operator()(int x) const { return x * 2; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> view(c);
+  EXPECT_EQ(view(21), 42);
+}
+
+TEST(ReflectionProtocolViewTest, CallOperatorFromLambda) {
+  struct Interface {
+    int operator()(int x) const;
+  };
+
+  // protocol_view can be constructed from a lambda directly, like
+  // function_ref.
+  auto lambda = [](int x) { return x * 2; };
+  protocol_view<Interface> view(lambda);
+  EXPECT_EQ(view(21), 42);
+}
+
+TEST(ReflectionProtocolViewTest, OverloadedCallOperators) {
+  struct Interface {
+    int operator()(int x);
+    double operator()(double x);
+    std::string operator()(const std::string& x) const;
+  };
+
+  struct Conforming {
+    int operator()(int x) { return x * 2; }
+
+    double operator()(double x) { return x * 3.0; }
+
+    std::string operator()(const std::string& x) const { return x + x; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> view(c);
+  EXPECT_EQ(view(5), 10);
+  EXPECT_EQ(view(5.0), 15.0);
+  EXPECT_EQ(view(std::string("A")), "AA");
+}
+
+TEST(ReflectionProtocolViewTest,
+     ConstAndNonConstCallOperatorPairDispatchesToNonConst) {
+  struct Interface {
+    int operator()() const;
+    int operator()();
+  };
+
+  struct Conforming {
+    int operator()() const { return 1; }
+
+    int operator()() { return 2; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> view(c);
+  EXPECT_EQ(view(), 2);
+
+  // Shallow const: a const protocol_view still dispatches to the non-const
+  // overload.
+  const protocol_view<Interface>& const_view = view;
+  EXPECT_EQ(const_view(), 2);
+}
+
+TEST(ReflectionProtocolViewTest, ConstViewDispatchesToConstCallOperator) {
+  struct Interface {
+    int operator()() const;
+    int operator()();
+  };
+
+  struct Conforming {
+    int operator()() const { return 1; }
+
+    int operator()() { return 2; }
+  };
+
+  Conforming c;
+  protocol_view<const Interface> view(c);
+  EXPECT_EQ(view(), 1);
+
+  const Conforming const_c;
+  protocol_view<const Interface> const_view(const_c);
+  EXPECT_EQ(const_view(), 1);
+}
+
+TEST(ReflectionProtocolViewTest, ConstViewExposesOnlyConstCallOperators) {
+  struct Interface {
+    int operator()() const;
+    void operator()(int value);
+  };
+
+  static_assert(!is_callable_with_int<protocol_view<const Interface>>);
+  static_assert(is_callable_with_int<protocol_view<Interface>>);
+  static_assert(is_callable_with_int<const protocol_view<Interface>>);
+
+  static_assert(is_callable<protocol_view<const Interface>>);
+  static_assert(is_callable<protocol_view<Interface>>);
+  static_assert(is_callable<const protocol_view<Interface>>);
+}
+
+TEST(ReflectionProtocolViewTest, CallOperatorAlongsideNamedMembers) {
+  struct Interface {
+    int operator()(int x) const;
+    int get() const;
+  };
+
+  struct Conforming {
+    int operator()(int x) const { return x * 2; }
+
+    int get() const { return 7; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> view(c);
+  EXPECT_EQ(view(2), 4);
+  EXPECT_EQ(view.get(), 7);
+}
+
+TEST(ReflectionProtocolViewTest, IsTriviallyCopyableWithCallOperator) {
+  struct Interface {
+    int operator()(int x);
+    double operator()(double x);
+    std::string operator()(const std::string& x) const;
+  };
+
+  static_assert(std::is_trivially_copyable_v<protocol_view<Interface>>);
+  static_assert(std::is_trivially_copyable_v<protocol_view<const Interface>>);
+  static_assert(sizeof(protocol_view<Interface>) == 2 * sizeof(void*));
 }
 
 // Member function forwarding tests for protocol.
@@ -1558,5 +1771,129 @@ TEST(ReflectionProtocolTest, NoexceptOverload) {
   EXPECT_EQ(p.f(5.0), 15);
   static_assert(noexcept(p.f(1)));
   static_assert(!noexcept(p.f(1.0)));
+}
+
+// Call operator tests for protocol.
+
+TEST(ReflectionProtocolTest, CallOperator) {
+  struct Interface {
+    int operator()(int x) const;
+  };
+
+  struct Conforming {
+    int operator()(int x) const { return x * 2; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p(21), 42);
+}
+
+TEST(ReflectionProtocolTest, CallOperatorFromLambda) {
+  struct Interface {
+    int operator()(int x) const;
+  };
+
+  protocol<Interface> p([](int x) { return x * 2; });
+  EXPECT_EQ(p(21), 42);
+}
+
+TEST(ReflectionProtocolTest, OverloadedCallOperators) {
+  struct Interface {
+    int operator()(int x);
+    double operator()(double x);
+    std::string operator()(const std::string& x) const;
+  };
+
+  struct Conforming {
+    int operator()(int x) { return x * 2; }
+
+    double operator()(double x) { return x * 3.0; }
+
+    std::string operator()(const std::string& x) const { return x + x; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p(5), 10);
+  EXPECT_EQ(p(5.0), 15.0);
+
+  const auto& const_p = p;
+  EXPECT_EQ(const_p(std::string("A")), "AA");
+}
+
+TEST(ReflectionProtocolTest, ConstAndNonConstCallOperatorPair) {
+  struct Interface {
+    int operator()() const;
+    int operator()();
+  };
+
+  struct Conforming {
+    int operator()() const { return 1; }
+
+    int operator()() { return 2; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p(), 2);
+
+  const protocol<Interface>& const_p = p;
+  EXPECT_EQ(const_p(), 1);
+}
+
+TEST(ReflectionProtocolTest, ConstProtocolExposesOnlyConstCallOperators) {
+  struct Interface {
+    int operator()() const;
+    void operator()(int value);
+  };
+
+  static_assert(!is_callable_with_int<const protocol<Interface>>);
+  static_assert(is_callable_with_int<protocol<Interface>>);
+
+  static_assert(is_callable<protocol<Interface>>);
+  static_assert(is_callable<const protocol<Interface>>);
+}
+
+TEST(ReflectionProtocolTest, CallOperatorAlongsideNamedMembers) {
+  struct Interface {
+    int operator()(int x) const;
+    int get() const;
+  };
+
+  struct Conforming {
+    int operator()(int x) const { return x * 2; }
+
+    int get() const { return 7; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p(2), 4);
+  EXPECT_EQ(p.get(), 7);
+}
+
+TEST(ReflectionProtocolTest, NoexceptCallOperator) {
+  struct Interface {
+    int operator()(int x) noexcept;
+  };
+
+  struct Conforming {
+    int operator()(int x) noexcept { return x * 2; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  EXPECT_EQ(p(21), 42);
+  static_assert(noexcept(p(1)));
+}
+
+TEST(ReflectionProtocolTest, CallOperatorForwardingAfterCopy) {
+  struct Interface {
+    int operator()(int x) const;
+  };
+
+  struct Conforming {
+    int operator()(int x) const { return x * 2; }
+  };
+
+  protocol<Interface> p(Conforming{});
+  protocol<Interface> copy(p);
+  EXPECT_EQ(copy(21), 42);
 }
 }  // namespace


### PR DESCRIPTION
Closes #210.

- `protocol_interface_functions_of` now includes `operator()`; `same_name` treats all call operators as one name, so conformance and overload grouping work as for named members. Lambdas conform (`protocol<Function> p([](int x) { ... })`, `protocol_view<Function>` as `function_ref`).
- Call operators get a `call_operator_base` wrapper base deriving from the `member_thunk` overload set, so `p(args)` works directly; protected special members keep it copyable by `protocol`/`protocol_view` but not sliceable.
- `method_thunk::enclosing` now uses `static_cast` when `EnclosingType` derives from the thunk, keeping the vanishing-this `reinterpret_cast` only for the `member_base` data-member case.
- Vtable entries for call operators are named `call_operator_<index>`.
- Const propagation, shallow const and `protocol_view<const I>` behave as for named overloads.

Re-opens #221 against main: it was squash-merged into `reflection-overloads-209` after #220 had already landed, so main never received it.
