### PR TITLE
Support static member functions on conformant types in the reflection implementation

### DIFF
--- a/reflection/protocol.hh
+++ b/reflection/protocol.hh
@@ -104,17 +104,10 @@ consteval std::string_view member_name(std::meta::info member) {
 }
 
 // Returns `true` if the member functions `candidate` and `interface` have
-// the same name, reference qualifiers, de-aliased return type and de-aliased
-// parameter types; const and noexcept are not compared.
-consteval bool same_signature_ignoring_const(std::meta::info candidate,
-                                             std::meta::info interface) {
+// the same name, de-aliased return type and de-aliased parameter types.
+consteval bool same_name_and_parameters(std::meta::info candidate,
+                                        std::meta::info interface) {
   if (!same_name(candidate, interface)) return false;
-  if (is_lvalue_reference_qualified(interface) !=
-      is_lvalue_reference_qualified(candidate))
-    return false;
-  if (is_rvalue_reference_qualified(interface) !=
-      is_rvalue_reference_qualified(candidate))
-    return false;
   if (dealias(return_type_of(interface)) != dealias(return_type_of(candidate)))
     return false;
   auto dealiased_type_of = [](std::meta::info parameter) {
@@ -124,29 +117,45 @@ consteval bool same_signature_ignoring_const(std::meta::info candidate,
                             {}, dealiased_type_of, dealiased_type_of);
 }
 
+// Returns `true` if the member functions `candidate` and `interface` have
+// the same name, reference qualifiers, de-aliased return type and de-aliased
+// parameter types; const and noexcept are not compared.
+consteval bool same_signature_ignoring_const(std::meta::info candidate,
+                                             std::meta::info interface) {
+  if (is_lvalue_reference_qualified(interface) !=
+      is_lvalue_reference_qualified(candidate))
+    return false;
+  if (is_rvalue_reference_qualified(interface) !=
+      is_rvalue_reference_qualified(candidate))
+    return false;
+  return same_name_and_parameters(candidate, interface);
+}
+
 // Returns `true` if the `candidate` member function is consistent with the
 // `interface` member function for the purposes of structural subtyping;
 // otherwise returns `false`.
 consteval bool member_function_conforms_to(std::meta::info candidate,
                                            std::meta::info interface) {
-  if (!same_signature_ignoring_const(candidate, interface)) return false;
-  // If interface is `const`, `candidate` must be const.
-  if (is_const(interface) != is_const(candidate)) return false;
+  if (is_static_member(candidate)) {
+    // A static candidate has no object parameter, so it satisfies any const
+    // or reference qualification of `interface`.
+    if (!same_name_and_parameters(candidate, interface)) return false;
+  } else {
+    if (!same_signature_ignoring_const(candidate, interface)) return false;
+    // If interface is `const`, `candidate` must be const.
+    if (is_const(interface) != is_const(candidate)) return false;
+  }
   // If interface is `noexcept`, `candidate` must be noexcept.
   return !is_noexcept(interface) || is_noexcept(candidate);
 }
 
-// The named, non-static, non-special member functions and call operators of
-// `Type`, in declaration order. Overloads appear as separate entries; an
-// entry's index identifies its vtable slot.
-//
-// TODO(jbcoe): Handle static functions as they can be used to satisfy
-// interface conformance.
+// The named, non-special member functions and call operators of `Type`,
+// static or not, in declaration order: the members that can satisfy an
+// interface member function.
 template <std::meta::info Type>
-consteval auto protocol_interface_function_infos() {
+consteval auto conformance_candidate_infos() {
   auto named = members_of(Type, std::meta::access_context::unprivileged()) |
                std::views::filter(std::meta::is_function) |
-               std::views::filter(std::not_fn(std::meta::is_static_member)) |
                std::views::filter([](std::meta::info member) consteval {
                  return has_identifier(member) || is_call_operator(member);
                });
@@ -164,8 +173,17 @@ consteval auto protocol_interface_function_infos() {
 }
 
 template <std::meta::info Type>
+constexpr inline auto conformance_candidates_of =
+    std::define_static_array(conformance_candidate_infos<Type>());
+
+// The non-static members of `conformance_candidates_of<Type>`: the member
+// functions an interface `Type` requires. Overloads appear as separate
+// entries; an entry's index identifies its vtable slot.
+template <std::meta::info Type>
 constexpr inline auto protocol_interface_functions_of =
-    std::define_static_array(protocol_interface_function_infos<Type>());
+    std::define_static_array(
+        conformance_candidates_of<Type> |
+        std::views::filter(std::not_fn(std::meta::is_static_member)));
 
 // The vtable entry for the interface member function at `Index`;
 // `generate_vtable_specs` declares one entry per interface member function in
@@ -506,8 +524,7 @@ struct vtable_generator {
 // `Member`, using the same matching rule as is_protocol_conformant.
 template <std::meta::info Member, std::meta::info CandidateType>
 consteval std::meta::info find_conforming_member() {
-  for (std::meta::info candidate :
-       protocol_interface_functions_of<CandidateType>) {
+  for (std::meta::info candidate : conformance_candidates_of<CandidateType>) {
     if (member_function_conforms_to(candidate, Member)) return candidate;
   }
   std::unreachable();
@@ -606,7 +623,7 @@ consteval bool is_protocol_conformant() {
   auto interface_member_functions =
       detail::protocol_interface_functions_of<^^Interface>;
   auto candidate_member_functions =
-      detail::protocol_interface_functions_of<^^Candidate>;
+      detail::conformance_candidates_of<^^Candidate>;
 
   return std::ranges::all_of(
       interface_member_functions, [&](std::meta::info interface_member) {

--- a/reflection/protocol_test.cc
+++ b/reflection/protocol_test.cc
@@ -702,6 +702,119 @@ TEST(ConformsToTest, OverloadedCallOperatorsConform) {
   static_assert(!is_protocol_conformant<Interface, MissingOverloads>());
 }
 
+TEST(ConformsToTest, StaticCandidateConformsToConstMember) {
+  struct Interface {
+    int value() const;
+  };
+
+  struct Conforming {
+    static int value();
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+}
+
+TEST(ConformsToTest, StaticCandidateConformsToNonConstMember) {
+  struct Interface {
+    int next();
+  };
+
+  struct Conforming {
+    static int next();
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+}
+
+TEST(ConformsToTest, StaticCandidateConformsToRefQualifiedMember) {
+  struct Interface {
+    int get() &;
+    int take() &&;
+  };
+
+  struct Conforming {
+    static int get();
+
+    static int take();
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+}
+
+TEST(ConformsToTest, StaticCandidateWithWrongSignatureDoesNotConform) {
+  struct Interface {
+    int value(int x) const;
+  };
+
+  struct WrongParam {
+    static int value(double x);
+  };
+
+  struct WrongReturn {
+    static double value(int x);
+  };
+
+  static_assert(!is_protocol_conformant<Interface, WrongParam>());
+  static_assert(!is_protocol_conformant<Interface, WrongReturn>());
+}
+
+TEST(ConformsToTest, NoexceptInterfaceRequiresNoexceptStaticCandidate) {
+  struct Interface {
+    int value() const noexcept;
+  };
+
+  struct Conforming {
+    static int value() noexcept;
+  };
+
+  struct NonNoexcept {
+    static int value();
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+  static_assert(!is_protocol_conformant<Interface, NonNoexcept>());
+}
+
+TEST(ConformsToTest, InterfaceStaticMembersAreIgnored) {
+  struct Interface {
+    static int helper();
+    int value() const;
+  };
+
+  struct Conforming {
+    int value() const { return 1; }
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+}
+
+TEST(ConformsToTest, StaticCallOperatorConforms) {
+  struct Interface {
+    int operator()(int x) const;
+  };
+
+  struct Conforming {
+    static int operator()(int x) { return x + 1; }
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+}
+
+TEST(ConformsToTest, StaticOverloadConformsAlongsideNonStatic) {
+  struct Interface {
+    int f(int x) const;
+    int f(double x) const;
+  };
+
+  struct Conforming {
+    int f(int x) const { return x; }
+
+    static int f(double x) { return static_cast<int>(x); }
+  };
+
+  static_assert(is_protocol_conformant<Interface, Conforming>());
+}
+
 // ---------------------------------------------------------------------------
 // Constructability tests.
 // ---------------------------------------------------------------------------
@@ -1294,6 +1407,91 @@ TEST(ReflectionProtocolViewTest, IsTriviallyCopyableWithCallOperator) {
   static_assert(sizeof(protocol_view<Interface>) == 2 * sizeof(void*));
 }
 
+TEST(ReflectionProtocolViewTest, StaticMemberFunction) {
+  struct Interface {
+    int value() const;
+  };
+
+  struct Conforming {
+    static int value() { return 42; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> view(c);
+  EXPECT_EQ(view.value(), 42);
+}
+
+TEST(ReflectionProtocolViewTest, ConstViewCallsStaticMemberFunction) {
+  struct Interface {
+    int value() const;
+  };
+
+  struct Conforming {
+    static int value() { return 42; }
+  };
+
+  const Conforming c;
+  protocol_view<const Interface> view(c);
+  EXPECT_EQ(view.value(), 42);
+}
+
+TEST(ReflectionProtocolViewTest, StaticMemberFunctionSatisfiesNonConstMember) {
+  struct Interface {
+    int next();
+  };
+
+  struct Conforming {
+    static int next() {
+      static int counter = 0;
+      return ++counter;
+    }
+  };
+
+  Conforming c;
+  protocol_view<Interface> view(c);
+  EXPECT_EQ(view.next(), 1);
+  EXPECT_EQ(view.next(), 2);
+}
+
+TEST(ReflectionProtocolViewTest,
+     StaticMemberFunctionAlongsideNonStaticMembers) {
+  struct Interface {
+    int value() const;
+    int add(int x);
+  };
+
+  struct Conforming {
+    int total = 0;
+
+    static int value() { return 3; }
+
+    int add(int x) {
+      total += x;
+      return total;
+    }
+  };
+
+  Conforming c;
+  protocol_view<Interface> view(c);
+  EXPECT_EQ(view.value(), 3);
+  EXPECT_EQ(view.add(4), 4);
+  EXPECT_EQ(view.add(5), 9);
+}
+
+TEST(ReflectionProtocolViewTest, StaticCallOperator) {
+  struct Interface {
+    int operator()(int x) const;
+  };
+
+  struct Conforming {
+    static int operator()(int x) { return x * 3; }
+  };
+
+  Conforming c;
+  protocol_view<Interface> view(c);
+  EXPECT_EQ(view(5), 15);
+}
+
 // Member function forwarding tests for protocol.
 
 TEST(ReflectionProtocolTest, ConstMemberFunction) {
@@ -1424,6 +1622,36 @@ TEST(ReflectionProtocolTest, MixedConstAndMutatingMemberFunctions) {
   EXPECT_EQ(p.get(), 0);
   p.set(7);
   EXPECT_EQ(p.get(), 7);
+}
+
+TEST(ReflectionProtocolTest, StaticMemberFunction) {
+  struct Interface {
+    int value() const;
+  };
+
+  struct Conforming {
+    static int value() { return 42; }
+  };
+
+  protocol<Interface> p(std::in_place_type<Conforming>);
+  EXPECT_EQ(p.value(), 42);
+}
+
+TEST(ReflectionProtocolTest, StaticMemberFunctionSatisfiesNonConstMember) {
+  struct Interface {
+    int next();
+  };
+
+  struct Conforming {
+    static int next() {
+      static int counter = 0;
+      return ++counter;
+    }
+  };
+
+  protocol<Interface> p(std::in_place_type<Conforming>);
+  EXPECT_EQ(p.next(), 1);
+  EXPECT_EQ(p.next(), 2);
 }
 
 TEST(ReflectionProtocolTest, ForwardingAfterCopyConstruction) {


### PR DESCRIPTION
Closes #211.

- `conformance_candidates_of<Type>` lists the named and call-operator member functions of a type, static or not; `is_protocol_conformant` and `find_conforming_member` search it. `protocol_interface_functions_of` is the non-static subset and remains the interface list, so an interface's own statics are still ignored.
- `member_function_conforms_to` skips the const and ref-qualifier checks for a static candidate, which has no object parameter; name, return type, parameter types and the noexcept rule still apply.
- The vtable trampolines are unchanged: `object->static_member(args)` is already valid C++.

Replaces #226. Depends on #233 and carries its commit until it lands; will be rebased onto main after that.
