### PR TITLE
Give the vscode devcontainer user UID 1000 and document credential sharing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,11 @@
 		"type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,readonly"
 	],
 	"customizations": {
+		"vscode": {
+			"extensions": [
+				"anthropic.claude-code"
+			]
+		},
 		"codespaces": {
 			"repositories": {
 				"jbcoe/cc-protocol": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,18 @@
 		"context": ".."
 	},
 	"remoteUser": "vscode",
+	// Host credentials are shared with the container by bind-mounting them into
+	// the `vscode` home directory. Only `~/.ssh` is mounted by default. To reuse
+	// your GitHub CLI login (`gh auth login` on the host) and your Claude Code
+	// login, add these entries locally; every source path must exist on the host
+	// or Docker refuses to start the container:
+	//
+	//   "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.config/gh,target=/home/vscode/.config/gh",
+	//   "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.claude,target=/home/vscode/.claude",
+	//   "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.claude.json,target=/home/vscode/.claude.json"
+	//
+	// The `vscode` user is created with UID 1000 (see docker/Dockerfile) so that
+	// these mounted files stay readable and writable on Linux and WSL hosts.
 	"mounts": [
 		"type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,readonly"
 	],

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,15 @@ RUN ARCH=$(dpkg --print-architecture) && \
     && rm /tmp/jj.tar.gz
 
 # Create non-root user.
-RUN useradd -m -s /bin/bash vscode \
+#
+# Ubuntu 24.04+ base images ship a default `ubuntu` user at UID/GID 1000, so
+# a plain `useradd vscode` would land on 1001. Host config directories that
+# are bind-mounted at runtime (~/.claude, ~/.gemini, ~/.ssh, ...) are almost
+# always owned by UID 1000, and VS Code's `updateRemoteUserUID` cannot remap
+# `vscode` onto an ID that is already taken. Remove the stock user first so
+# `vscode` gets 1000:1000 and the mounted files are readable and writable.
+RUN userdel -r ubuntu \
+    && useradd -m -s /bin/bash --uid 1000 vscode \
     && mkdir -p /workspace \
     && chown vscode:vscode /workspace
 


### PR DESCRIPTION
`ubuntu:24.04` and later ship a default `ubuntu` user at 1000:1000, so `useradd vscode` in the Dockerfile landed on UID 1001. On Linux and WSL hosts, directories bind-mounted from the host are owned by UID 1000, and VS Code's `updateRemoteUserUID` cannot remap `vscode` onto an ID that is already taken. Remove the stock user before creating `vscode` so it gets 1000:1000.

Docker Desktop on macOS and Codespaces are unaffected either way.

`devcontainer.json` gains a comment showing the optional bind mounts for reusing a host `gh auth login` and Claude Code login inside the container (`~/.config/gh`, `~/.claude`, `~/.claude.json`). They are not enabled by default because Docker refuses to start the container when a bind source is missing.

Also recommends the Claude Code VS Code extension, matching the `CLAUDE.md` in the repository.
