### PR TITLE
Prepare build, sanitizer and uv-lock jobs to be required status checks

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,21 +13,55 @@ on:
       - "**/CMakeLists.txt"
       - "CMakePresets.json"
       - "**/*.cmake"
+      - "scripts/cmake.py"
+      - "scripts/cmake.sh"
+  # No `paths:` filter here. The `GCC trunk` build jobs are required status
+  # checks for merging to main, and a workflow that is filtered out by
+  # `paths:` never reports a check, which leaves unrelated pull requests
+  # blocked as "Expected - Waiting for status to be reported". Instead, the
+  # `detect-changes` job below decides whether the build needs to run, and a
+  # job skipped by an `if:` condition counts as a passing check.
   pull_request:
-    paths:
-      - ".github/workflows/cmake.yml" # This file
-      - "**/*.cc"
-      - "**/*.h"
-      - "**/*.hh"
-      - "**/CMakeLists.txt"
-      - "CMakePresets.json"
-      - "**/*.cmake"
 
 env:
   UV_FROZEN: 1
 
 jobs:
+  detect-changes:
+    name: detect-changes (cmake)
+    # Only pull requests need change detection; pushes to main and scheduled
+    # runs always run the build.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Keep in sync with the `push.paths` list above.
+          filters: |
+            relevant:
+              - ".github/workflows/cmake.yml" # This file
+              - "**/*.cc"
+              - "**/*.h"
+              - "**/*.hh"
+              - "**/CMakeLists.txt"
+              - "CMakePresets.json"
+              - "**/*.cmake"
+              - "scripts/cmake.py"
+              - "scripts/cmake.sh"
+
   build:
+    needs: detect-changes
+    # Run unless change detection positively reported that nothing relevant
+    # changed. `!cancelled()` lets this job run when `detect-changes` was
+    # skipped (push and schedule events), and an empty output (because
+    # `detect-changes` failed) falls through to running the build rather than
+    # silently passing the required check.
+    if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
     name: ${{ matrix.settings.name }} ${{ matrix.configuration }}
     runs-on: ${{ matrix.settings.os }}
     continue-on-error: ${{ matrix.settings.informational || false }}
@@ -37,7 +71,7 @@ jobs:
         configuration: ["Release", "Debug"]
         settings:
           - {
-              name: "Ubuntu GCC trunk (C++26 Reflection)",
+              name: "GCC trunk",
               os: ubuntu-26.04,
               compiler:
                 {
@@ -55,7 +89,7 @@ jobs:
           # above is the gating one. Drop this entry once the reflection backend
           # needs fixes that only exist on trunk.
           - {
-              name: "Ubuntu GCC-16 (C++26 Reflection, informational)",
+              name: "GCC-16 (informational)",
               os: ubuntu-26.04,
               compiler:
                 {

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -64,7 +64,6 @@ jobs:
     if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
     name: ${{ matrix.settings.name }} ${{ matrix.configuration }}
     runs-on: ${{ matrix.settings.os }}
-    continue-on-error: ${{ matrix.settings.informational || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -84,12 +83,11 @@ jobs:
             }
           # Ubuntu 26.04's gcc-16 is a frozen experimental snapshot whose
           # reflection support no longer receives fixes (issue #122). It is kept
-          # here as a non-blocking, informational job because it is what a stock
-          # Ubuntu 26.04 user gets from `apt install gcc-16`; the GCC trunk job
-          # above is the gating one. Drop this entry once the reflection backend
+          # because it is what a stock Ubuntu 26.04 user gets from
+          # `apt install gcc-16`. Drop this entry once the reflection backend
           # needs fixes that only exist on trunk.
           - {
-              name: "GCC-16 (informational)",
+              name: "GCC-16",
               os: ubuntu-26.04,
               compiler:
                 {
@@ -99,7 +97,6 @@ jobs:
                   cxx: "g++-16",
                   std: 26,
                 },
-              informational: true,
             }
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -14,23 +14,55 @@ on:
       - "CMakePresets.json"
       - "**/*.cmake"
       - "scripts/cmake.py"
+      - "scripts/cmake.sh"
+  # No `paths:` filter here. The `asan` and `tsan` jobs are required status
+  # checks for merging to main, and a workflow that is filtered out by
+  # `paths:` never reports a check, which leaves unrelated pull requests
+  # blocked as "Expected - Waiting for status to be reported". Instead, the
+  # `detect-changes` job below decides whether the build needs to run, and a
+  # job skipped by an `if:` condition counts as a passing check.
   pull_request:
-    paths:
-      - ".github/workflows/sanitizers.yml"
-      - "**/*.cc"
-      - "**/*.h"
-      - "**/*.hh"
-      - "**/CMakeLists.txt"
-      - "CMakePresets.json"
-      - "**/*.cmake"
-      - "scripts/cmake.py"
 
 env:
   UV_FROZEN: 1
 
 jobs:
+  detect-changes:
+    name: detect-changes (sanitizers)
+    # Only pull requests need change detection; pushes to main and scheduled
+    # runs always run the build.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Keep in sync with the `push.paths` list above.
+          filters: |
+            relevant:
+              - ".github/workflows/sanitizers.yml"
+              - "**/*.cc"
+              - "**/*.h"
+              - "**/*.hh"
+              - "**/CMakeLists.txt"
+              - "CMakePresets.json"
+              - "**/*.cmake"
+              - "scripts/cmake.py"
+              - "scripts/cmake.sh"
+
   sanitized-tests:
-    name: ${{ matrix.sanitizer }} (GCC trunk)
+    needs: detect-changes
+    # Run unless change detection positively reported that nothing relevant
+    # changed. `!cancelled()` lets this job run when `detect-changes` was
+    # skipped (push and schedule events), and an empty output (because
+    # `detect-changes` failed) falls through to running the build rather than
+    # silently passing the required check.
+    if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
+    name: ${{ matrix.sanitizer }}
     runs-on: ubuntu-26.04
     strategy:
       fail-fast: false

--- a/.github/workflows/uv-lock.yml
+++ b/.github/workflows/uv-lock.yml
@@ -6,17 +6,18 @@ on:
     paths:
       - pyproject.toml
       - uv.lock
+  # No `paths:` filter here. This is a required status check for merging to
+  # main, but the job is cheap (checkout + `uv lock --check`), so it always
+  # runs rather than needing a `detect-changes` job.
   pull_request:
     branches: [main]
-    paths:
-      - pyproject.toml
-      - uv.lock
 
 env:
   UV_FROZEN: 1
 
 jobs:
   check-lockfile:
+    name: uv-lock
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,11 @@ The script will configure, build, and execute tests.
 
 Pull requests run the workflows in `.github/workflows`. The following checks
 are required for merging to `main`: `GCC trunk Release`, `GCC trunk Debug`,
-`asan`, `tsan`, `uv-lock`, `pre-commit`.
+`GCC-16 Release`, `GCC-16 Debug`, `asan`, `tsan`, `uv-lock`, `pre-commit`.
 
 On pull requests that touch no C++, CMake, or build-script sources, the build
 and sanitizer jobs are skipped by a change-detection job, which counts as
-passing. The `GCC-16 (informational)` builds never block a merge.
+passing.
 
 ## Core Concepts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,16 @@ This script manages the entire build and test process.
 
 The script will configure, build, and execute tests.
 
+### Continuous Integration
+
+Pull requests run the workflows in `.github/workflows`. The following checks
+are required for merging to `main`: `GCC trunk Release`, `GCC trunk Debug`,
+`asan`, `tsan`, `uv-lock`, `pre-commit`.
+
+On pull requests that touch no C++, CMake, or build-script sources, the build
+and sanitizer jobs are skipped by a change-detection job, which counts as
+passing. The `GCC-16 (informational)` builds never block a merge.
+
 ## Core Concepts
 
 ### Structural Subtyping


### PR DESCRIPTION
Refs #213.

Workflow-side preparation for making the build, sanitizer and lockfile jobs required status checks on `main`, following the approach from #188: the `pull_request` triggers lose their `paths:` filters so every pull request reports these checks, and a `detect-changes` job (`dorny/paths-filter`) skips the expensive jobs when nothing relevant changed. A job skipped by `if:` counts as a passing check. `uv-lock` is cheap enough to always run.

Job names are shortened so the ruleset contexts are short and stable. After this merges, add these contexts to the `main` ruleset under *Require status checks to pass* (needs admin):

- `GCC trunk Release`
- `GCC trunk Debug`
- `GCC-16 Release`
- `GCC-16 Debug`
- `asan`
- `tsan`
- `uv-lock`
- `pre-commit` (already required)

**Enable the ruleset entries only after this merges**: with the current `paths:` filters a required check that never reports would block every non-C++ pull request.
