### PR TITLE
Valueless checks

### DIFF
--- a/protocol.hh
+++ b/protocol.hh
@@ -236,7 +236,8 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Index,
   {
     auto* protocol_object = static_cast<ProtocolType*>(enclosing(this));
     if constexpr (is_protocol_v<ProtocolType>) {
-      assert(!protocol_object->valueless_after_move() && "cannot call member function of valueless protocol");
+      assert(!protocol_object->valueless_after_move() &&
+             "cannot call member function of valueless protocol");
     }
 
     const Vtable* vtable = protocol_object->vtable_;
@@ -251,9 +252,10 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Index,
     const auto* protocol_object =
         static_cast<const ProtocolType*>(enclosing(this));
     if constexpr (is_protocol_v<ProtocolType>) {
-      assert(!protocol_object->valueless_after_move() && "cannot call member function of valueless protocol");
+      assert(!protocol_object->valueless_after_move() &&
+             "cannot call member function of valueless protocol");
     }
-    
+
     const Vtable* vtable = protocol_object->vtable_;
     constexpr std::meta::info entry = vtable_entry;
     return vtable->[:entry:](protocol_object->object_,
@@ -471,8 +473,8 @@ consteval std::meta::info generate_wrapper_bases() {
 template <typename T, typename ProtocolType, typename Vtable,
           const_policy ConstPolicy = const_policy::propagate>
 using protocol_wrappers_t =
-    typename[:generate_wrapper_bases<^^T, ProtocolType, Vtable,
-                                     ConstPolicy>():];
+    typename[:generate_wrapper_bases<^^T, ProtocolType, Vtable, ConstPolicy>(
+                  ):];
 
 // Names the vtable entry for the interface member function at `index`.
 // Overloads share an identifier, so the index keeps entry names unique.

--- a/protocol.hh
+++ b/protocol.hh
@@ -235,6 +235,10 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Index,
     requires(!IsConst)
   {
     auto* protocol_object = static_cast<ProtocolType*>(enclosing(this));
+    if constexpr (is_protocol_v<ProtocolType>) {
+      assert(!protocol_object->valueless_after_move() && "cannot call member function of valueless protocol");
+    }
+
     const Vtable* vtable = protocol_object->vtable_;
     constexpr std::meta::info entry = vtable_entry;
     return vtable->[:entry:](protocol_object->object_,
@@ -246,6 +250,10 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Index,
   {
     const auto* protocol_object =
         static_cast<const ProtocolType*>(enclosing(this));
+    if constexpr (is_protocol_v<ProtocolType>) {
+      assert(!protocol_object->valueless_after_move() && "cannot call member function of valueless protocol");
+    }
+    
     const Vtable* vtable = protocol_object->vtable_;
     constexpr std::meta::info entry = vtable_entry;
     return vtable->[:entry:](protocol_object->object_,

--- a/protocol.hh
+++ b/protocol.hh
@@ -473,7 +473,7 @@ consteval std::meta::info generate_wrapper_bases() {
 template <typename T, typename ProtocolType, typename Vtable,
           const_policy ConstPolicy = const_policy::propagate>
 using protocol_wrappers_t =
-    typename[:generate_wrapper_bases<^^T, ProtocolType, Vtable, 
+    typename[:generate_wrapper_bases<^^T, ProtocolType, Vtable,
                                      ConstPolicy>():];
 
 // Names the vtable entry for the interface member function at `index`.

--- a/protocol.hh
+++ b/protocol.hh
@@ -473,8 +473,8 @@ consteval std::meta::info generate_wrapper_bases() {
 template <typename T, typename ProtocolType, typename Vtable,
           const_policy ConstPolicy = const_policy::propagate>
 using protocol_wrappers_t =
-    typename[:generate_wrapper_bases<^^T, ProtocolType, Vtable, ConstPolicy>(
-                  ):];
+    typename[:generate_wrapper_bases<^^T, ProtocolType, Vtable, 
+                                     ConstPolicy>():];
 
 // Names the vtable entry for the interface member function at `index`.
 // Overloads share an identifier, so the index keeps entry names unique.

--- a/protocol_test.cc
+++ b/protocol_test.cc
@@ -2124,4 +2124,46 @@ TEST(ReflectionProtocolTest, CallOperatorForwardingAfterCopy) {
   protocol<Interface> copy(p);
   EXPECT_EQ(copy(21), 42);
 }
+
+// Tests that dispatching fails gracefully for a moved-from protocol.
+#if (defined(_MSC_VER) && defined(_DEBUG)) || (!defined(NDEBUG))
+
+TEST(ReflectionProtocolTest, MutableValuelessCall) {
+  struct Interface {
+    int foo();
+  };
+
+  struct TypeA {
+    int foo() { return 5; }
+  };
+
+  protocol<Interface> p(TypeA{});
+  EXPECT_EQ(p.foo(), 5);
+
+  auto _ = std::move(p);
+  EXPECT_TRUE(p.valueless_after_move());
+
+  EXPECT_DEATH(p.foo(), "cannot call member function of valueless protocol");
+}
+
+TEST(ReflectionProtocolTest, ConstValuelessCall) {
+  struct Interface {
+    int foo() const;
+  };
+
+  struct TypeA {
+    int foo() const { return 5; }
+  };
+
+  protocol<Interface> p(TypeA{});
+  EXPECT_EQ(p.foo(), 5);
+
+  auto _ = std::move(p);
+  EXPECT_TRUE(p.valueless_after_move());
+
+  EXPECT_DEATH(p.foo(), "cannot call member function of valueless protocol");
+}
+
+#endif
+
 }  // namespace


### PR DESCRIPTION
Add null checks when a member function is called in a valueless protocol.

Closes #208