### PR TITLE
Use Itanium-ABI-like name mangling for vtable entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,9 @@ xyz_add_library(
   NAME protocol
   ALIAS xyz_protocol::protocol)
 target_sources(
-  protocol INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/protocol.hh>)
+  protocol
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/protocol.hh>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/name_mangling.h>)
 
 if(XYZ_PROTOCOL_IS_NOT_SUBPROJECT)
 
@@ -119,7 +121,8 @@ if(XYZ_PROTOCOL_IS_NOT_SUBPROJECT)
       protocol_test.cc
       allocator_tests.cc
       consteval_check_test.cc
-      forwarding_test.cc)
+      forwarding_test.cc
+      name_mangling_tests.cc)
 
     add_subdirectory(tutorials)
   endif(${BUILD_TESTING})

--- a/name_mangling.h
+++ b/name_mangling.h
@@ -20,20 +20,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef XYZ_REFLECTION_NAME_MANGLING_H_
 #define XYZ_REFLECTION_NAME_MANGLING_H_
 
-// Names a member function by mangling its signature, following the Itanium
-// C++ ABI where it has an encoding: the function name (or `cl` for the call
-// operator), wrapped in `N...E` with its cv- and ref-qualifiers when it has
-// any, followed by the parameter types. The name depends only on the
-// signature, so a member function of one class names the same entry as a
-// member function of the same signature on another class; this lets a
-// vtable's entries be found by the signature of the interface member function
-// they implement, rather than by declaration order.
-//
-// Parameter types may be fundamental, pointers, references, arrays,
-// functions, and (possibly cv-qualified) named class, union and enumeration
-// types, including class-template specialisations with type, integral or
-// enumeration template arguments. Naming an entry for any other parameter
-// type is ill-formed.
+// Names a member function with a string that's a valid C++ identifier: only
+// letters, digits and underscore, none of the characters (`:`, `(`, `)`,
+// `<`, `>`) that a plain rendering of a signature would contain. The
+// encoding reuses the Itanium C++ ABI's member-mangling scheme, which
+// already solves this problem for linker symbol names, rather than
+// inventing a new one.
 
 #include <array>
 #include <charconv>
@@ -248,11 +240,10 @@ consteval std::string base_name_of(std::meta::info function) {
 
 }  // namespace detail
 
-// Names a vtable entry for the member function `function`. Distinguishes
-// overloads by folding the function's cv- and ref-qualification, then each
-// parameter's type, into the name. Matches the Itanium ABI's own placement:
-// cv-/ref-qualifiers sit inside `N...E`, wrapping the function name, ahead of
-// the parameter list.
+// Names the member function `function`, distinguishing overloads by folding
+// its cv- and ref-qualification, then each parameter's type, into the name.
+// Matches the Itanium ABI's own placement: cv-/ref-qualifiers sit inside
+// `N...E`, wrapping the function name, ahead of the parameter list.
 consteval std::string mangle(std::meta::info function) {
   std::string qualifiers;
   if (is_volatile(function)) qualifiers += "V";

--- a/name_mangling.h
+++ b/name_mangling.h
@@ -1,0 +1,274 @@
+/* Copyright (c) 2025 The XYZ Protocol Authors. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==============================================================================*/
+#ifndef XYZ_REFLECTION_NAME_MANGLING_H_
+#define XYZ_REFLECTION_NAME_MANGLING_H_
+
+// Names a member function by mangling its signature, following the Itanium
+// C++ ABI where it has an encoding: the function name (or `cl` for the call
+// operator), wrapped in `N...E` with its cv- and ref-qualifiers when it has
+// any, followed by the parameter types. The name depends only on the
+// signature, so a member function of one class names the same entry as a
+// member function of the same signature on another class; this lets a
+// vtable's entries be found by the signature of the interface member function
+// they implement, rather than by declaration order.
+//
+// Parameter types may be fundamental, pointers, references, arrays,
+// functions, and (possibly cv-qualified) named class, union and enumeration
+// types, including class-template specialisations with type, integral or
+// enumeration template arguments. Naming an entry for any other parameter
+// type is ill-formed.
+
+#include <array>
+#include <charconv>
+#include <limits>
+#include <meta>
+#include <optional>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace xyz::name_mangling {
+
+namespace detail {
+
+consteval std::string decimal(std::size_t value) {
+  std::array<char, std::numeric_limits<std::size_t>::digits10 + 1> buffer;
+  auto result =
+      std::to_chars(buffer.data(), buffer.data() + buffer.size(), value);
+  return std::string(buffer.data(), result.ptr);
+}
+
+// Length-prefixed with no separator, as for an Itanium <source-name>.
+consteval std::string mangle_atom(std::string_view text) {
+  return decimal(text.size()) + std::string(text);
+}
+
+// Forward-declared: mutually recursive with `mangle_scope_component` via a
+// template argument that is itself a class-template specialisation.
+consteval std::string mangle_type(std::meta::info type);
+
+template <typename T>
+consteval std::string signed_decimal(std::meta::info argument) {
+  T value = extract<T>(argument);
+  if constexpr (std::is_signed_v<T>) {
+    if (value < 0) {
+      return "n" + decimal(std::size_t{0} - static_cast<std::size_t>(value));
+    }
+  }
+  return decimal(static_cast<std::size_t>(value));
+}
+
+// The decimal value of `argument` if its type is one of `Integral...`.
+template <typename... Integral>
+consteval std::optional<std::string> integral_decimal(
+    std::meta::info argument) {
+  std::meta::info type = dealias(type_of(argument));
+  std::optional<std::string> result;
+  ((type == ^^Integral ? (result = signed_decimal<Integral>(argument), true)
+                       : false) ||
+   ...);
+  return result;
+}
+
+// A non-type template argument as an Itanium <expr-primary>, `L<type><value>E`.
+// Enumeration values are written by enumerator name rather than numeric
+// value, which needs no knowledge of the underlying type.
+consteval std::string mangle_template_argument_value(std::meta::info argument) {
+  std::meta::info type = dealias(type_of(argument));
+  std::string out = "L" + mangle_type(type);
+  if (type == ^^bool) {
+    return out + (extract<bool>(argument) ? "1" : "0") + "E";
+  }
+  if (std::optional<std::string> value =
+          integral_decimal<char, signed char, unsigned char, wchar_t, char8_t,
+                           char16_t, char32_t, short, unsigned short, int,
+                           unsigned int, long, unsigned long, long long,
+                           unsigned long long>(argument)) {
+    return out + *value + "E";
+  }
+  if (is_enum_type(type)) {
+    std::vector<std::meta::info> enumerators = enumerators_of(type);
+    for (std::meta::info enumerator : enumerators) {
+      if (constant_of(enumerator) == argument) {
+        return out + mangle_atom(identifier_of(enumerator)) + "E";
+      }
+    }
+  }
+  throw std::runtime_error(
+      "name mangling: unsupported non-type template argument");
+}
+
+// Mangles one scope level (a namespace, class, enumeration or function),
+// folding in template arguments when `scope` is a class-template
+// specialisation.
+consteval std::string mangle_scope_component(std::meta::info scope) {
+  if (is_namespace(scope) && !has_identifier(scope)) return "12_GLOBAL__N_1";
+  std::meta::info named =
+      has_template_arguments(scope) ? template_of(scope) : scope;
+  if (!has_identifier(named)) {
+    throw std::runtime_error("name mangling: unnamed types are not supported");
+  }
+  std::string out = mangle_atom(identifier_of(named));
+  if (has_template_arguments(scope)) {
+    out += "I";
+    std::vector<std::meta::info> arguments = template_arguments_of(scope);
+    for (std::meta::info argument : arguments) {
+      if (is_type(argument)) {
+        out += mangle_type(argument);
+      } else if (is_value(argument)) {
+        out += mangle_template_argument_value(argument);
+      } else {
+        throw std::runtime_error(
+            "name mangling: unsupported template argument");
+      }
+    }
+    out += "E";
+  }
+  return out;
+}
+
+// Walks `parent_of` up to (not including) the global namespace, then wraps
+// 2+ levels in Itanium's N...E delimiters so a qualified name can't be
+// confused with a sequence of unqualified ones.
+consteval std::string mangle_qualified_name(std::meta::info type) {
+  std::vector<std::string> components;
+  for (std::meta::info scope = type; scope != ^^::;
+       scope = dealias(parent_of(scope))) {
+    components.push_back(mangle_scope_component(scope));
+  }
+  std::string joined;
+  for (const std::string& component : components | std::views::reverse) {
+    joined += component;
+  }
+  return components.size() > 1 ? "N" + joined + "E" : joined;
+}
+
+// Itanium ABI <builtin-type> codes for fundamental types.
+consteval std::optional<std::string_view> builtin_type_code(
+    std::meta::info type) {
+  constexpr std::array<std::pair<std::meta::info, std::string_view>, 21> codes{
+      {{^^void, "v"},
+       {^^bool, "b"},
+       {^^char, "c"},
+       {^^signed char, "a"},
+       {^^unsigned char, "h"},
+       {^^short, "s"},
+       {^^unsigned short, "t"},
+       {^^int, "i"},
+       {^^unsigned int, "j"},
+       {^^long, "l"},
+       {^^unsigned long, "m"},
+       {^^long long, "x"},
+       {^^unsigned long long, "y"},
+       {^^float, "f"},
+       {^^double, "d"},
+       {^^long double, "e"},
+       {^^wchar_t, "w"},
+       {^^char8_t, "Du"},
+       {^^char16_t, "Ds"},
+       {^^char32_t, "Di"},
+       {^^std::nullptr_t, "Dn"}}};
+  for (auto [builtin, code] : codes) {
+    if (dealias(builtin) == type) return code;
+  }
+  if (is_fundamental_type(type)) {
+    throw std::runtime_error(
+        "name mangling: no mnemonic for this fundamental type");
+  }
+  return std::nullopt;
+}
+
+// Recurses through cv/pointer/reference/array/function layers, tagging each
+// with its Itanium prefix, then descends to the pointee/referee/element.
+consteval std::string mangle_type(std::meta::info type) {
+  type = dealias(type);
+  if (is_const_type(type) || is_volatile_type(type)) {
+    std::string qualifiers = is_volatile_type(type) ? "V" : "";
+    if (is_const_type(type)) qualifiers += "K";
+    return qualifiers + mangle_type(remove_cv(type));
+  }
+  if (is_pointer_type(type)) return "P" + mangle_type(remove_pointer(type));
+  if (is_lvalue_reference_type(type)) {
+    return "R" + mangle_type(remove_reference(type));
+  }
+  if (is_rvalue_reference_type(type)) {
+    return "O" + mangle_type(remove_reference(type));
+  }
+  if (is_array_type(type)) {
+    std::string out = "A";
+    if (is_bounded_array_type(type)) out += decimal(extent(type));
+    return out + "_" + mangle_type(remove_extent(type));
+  }
+  if (is_function_type(type)) {
+    std::string out = is_noexcept(type) ? "DoF" : "F";
+    out += mangle_type(return_type_of(type));
+    std::vector<std::meta::info> parameters = parameters_of(type);
+    if (parameters.empty()) out += "v";
+    for (std::meta::info parameter : parameters) {
+      out += mangle_type(is_type(parameter) ? parameter : type_of(parameter));
+    }
+    return out + "E";
+  }
+  if (auto code = builtin_type_code(type)) return std::string(*code);
+  if (is_class_type(type) || is_union_type(type) || is_enum_type(type)) {
+    return mangle_qualified_name(type);
+  }
+  throw std::runtime_error("name mangling: unsupported parameter type");
+}
+
+// `identifier_of` throws for `operator()`, which has no identifier; use its
+// Itanium <operator-name> instead.
+consteval std::string base_name_of(std::meta::info function) {
+  if (is_operator_function(function) &&
+      operator_of(function) == std::meta::operators::op_parentheses) {
+    return "cl";
+  }
+  return std::string(identifier_of(function));
+}
+
+}  // namespace detail
+
+// Names a vtable entry for the member function `function`. Distinguishes
+// overloads by folding the function's cv- and ref-qualification, then each
+// parameter's type, into the name. Matches the Itanium ABI's own placement:
+// cv-/ref-qualifiers sit inside `N...E`, wrapping the function name, ahead of
+// the parameter list.
+consteval std::string mangle(std::meta::info function) {
+  std::string qualifiers;
+  if (is_volatile(function)) qualifiers += "V";
+  if (is_const(function)) qualifiers += "K";
+  if (is_lvalue_reference_qualified(function)) qualifiers += "R";
+  if (is_rvalue_reference_qualified(function)) qualifiers += "O";
+  std::string atom = detail::mangle_atom(detail::base_name_of(function));
+  std::string name =
+      "fn_" + (qualifiers.empty() ? atom : "N" + qualifiers + atom + "E");
+  std::vector<std::meta::info> parameters = parameters_of(function);
+  for (std::meta::info parameter : parameters) {
+    name += detail::mangle_type(type_of(parameter));
+  }
+  return name;
+}
+
+}  // namespace xyz::name_mangling
+
+#endif  // XYZ_REFLECTION_NAME_MANGLING_H_

--- a/name_mangling.h
+++ b/name_mangling.h
@@ -43,8 +43,9 @@ namespace xyz::name_mangling {
 
 namespace detail {
 
-consteval std::string decimal(std::size_t value) {
-  std::array<char, std::numeric_limits<std::size_t>::digits10 + 1> buffer;
+template <typename T>
+consteval std::string decimal(T value) {
+  std::array<char, std::numeric_limits<T>::digits10 + 1> buffer;
   auto result =
       std::to_chars(buffer.data(), buffer.data() + buffer.size(), value);
   return std::string(buffer.data(), result.ptr);
@@ -62,12 +63,14 @@ consteval std::string mangle_type(std::meta::info type);
 template <typename T>
 consteval std::string signed_decimal(std::meta::info argument) {
   T value = extract<T>(argument);
+  using Unsigned = std::make_unsigned_t<T>;
   if constexpr (std::is_signed_v<T>) {
     if (value < 0) {
-      return "n" + decimal(std::size_t{0} - static_cast<std::size_t>(value));
+      return "n" +
+             decimal(static_cast<Unsigned>(0) - static_cast<Unsigned>(value));
     }
   }
-  return decimal(static_cast<std::size_t>(value));
+  return decimal(static_cast<Unsigned>(value));
 }
 
 // The decimal value of `argument` if its type is one of `Integral...`.
@@ -158,7 +161,7 @@ consteval std::string mangle_qualified_name(std::meta::info type) {
 // Itanium ABI <builtin-type> codes for fundamental types.
 consteval std::optional<std::string_view> builtin_type_code(
     std::meta::info type) {
-  constexpr std::array<std::pair<std::meta::info, std::string_view>, 21> codes{
+  constexpr std::array<std::pair<std::meta::info, std::string_view>, 23> codes{
       {{^^void, "v"},
        {^^bool, "b"},
        {^^char, "c"},
@@ -172,6 +175,8 @@ consteval std::optional<std::string_view> builtin_type_code(
        {^^unsigned long, "m"},
        {^^long long, "x"},
        {^^unsigned long long, "y"},
+       {^^__int128, "n"},
+       {^^unsigned __int128, "o"},
        {^^float, "f"},
        {^^double, "d"},
        {^^long double, "e"},
@@ -228,31 +233,43 @@ consteval std::string mangle_type(std::meta::info type) {
   throw std::runtime_error("name mangling: unsupported parameter type");
 }
 
-// `identifier_of` throws for `operator()`, which has no identifier; use its
-// Itanium <operator-name> instead.
+// Returns the mangled function-name atom for `function`: the Itanium
+// <operator-name> `cl` for the call operator, or a length-prefixed
+// <source-name> for its identifier otherwise. `identifier_of` throws for
+// `operator()`, which has no identifier.
 consteval std::string base_name_of(std::meta::info function) {
   if (is_operator_function(function) &&
       operator_of(function) == std::meta::operators::op_parentheses) {
     return "cl";
   }
-  return std::string(identifier_of(function));
+  return mangle_atom(identifier_of(function));
 }
 
 }  // namespace detail
 
 // Names the member function `function`, distinguishing overloads by folding
-// its cv- and ref-qualification, then each parameter's type, into the name.
-// Matches the Itanium ABI's own placement: cv-/ref-qualifiers sit inside
-// `N...E`, wrapping the function name, ahead of the parameter list.
+// its cv- and ref-qualification, noexcept-ness, return type and each
+// parameter's type into the name. Matches the Itanium ABI's own placement
+// for the qualifiers: they sit inside `N...E`, wrapping the function name,
+// ahead of the return type and parameter list.
+//
+// C++ overload resolution never needs the return type or noexcept-ness to
+// disambiguate the member functions of one interface, so folding them in is
+// redundant there. It matters once a vtable entry is found by this name
+// across two different interfaces: two unrelated interfaces can each
+// declare `get() const` with a different return type or noexcept-ness, and
+// without this, both would mangle to the same entry name.
 consteval std::string mangle(std::meta::info function) {
   std::string qualifiers;
   if (is_volatile(function)) qualifiers += "V";
   if (is_const(function)) qualifiers += "K";
   if (is_lvalue_reference_qualified(function)) qualifiers += "R";
   if (is_rvalue_reference_qualified(function)) qualifiers += "O";
-  std::string atom = detail::mangle_atom(detail::base_name_of(function));
+  std::string atom = detail::base_name_of(function);
   std::string name =
       "fn_" + (qualifiers.empty() ? atom : "N" + qualifiers + atom + "E");
+  name += is_noexcept(function) ? "Do" : "";
+  name += detail::mangle_type(return_type_of(function));
   std::vector<std::meta::info> parameters = parameters_of(function);
   for (std::meta::info parameter : parameters) {
     name += detail::mangle_type(type_of(parameter));

--- a/name_mangling_tests.cc
+++ b/name_mangling_tests.cc
@@ -1,0 +1,95 @@
+// Tests for the Itanium-ABI-style member function name mangling used to name
+// vtable entries.
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+#include "name_mangling.h"
+
+using xyz::name_mangling::mangle;
+
+namespace {
+
+enum class Kind { one, two };
+
+template <int N>
+struct Tagged {};
+
+struct Widget {};
+
+struct Interface {
+  int get() const;
+  void update(int value);
+  int operator()(int value) const;
+  void set_int(int value);
+  void set_double(double value);
+  void set_widget_ref(const Widget& value);
+  void set_ptr(int* value);
+  void set_kind(Kind value);
+  void set_two(int value, int other);
+  void set_array(std::array<int, 3> value);
+  void set_tagged(Tagged<3> value);
+  void ref_lvalue() &;
+  void ref_rvalue() &&;
+};
+
+struct Other {
+  int get() const;
+};
+
+TEST(NameManglingTest, NamesAConstMemberFunctionWithNoParameters) {
+  static_assert(mangle(^^Interface::get) == "fn_NK3getE");
+}
+
+TEST(NameManglingTest, NamesAMemberFunctionWithAFundamentalParameter) {
+  static_assert(mangle(^^Interface::update) == "fn_6updatei");
+  static_assert(mangle(^^Interface::set_int) == "fn_7set_inti");
+  static_assert(mangle(^^Interface::set_double) == "fn_10set_doubled");
+}
+
+TEST(NameManglingTest, NamesTheCallOperatorUsingItsOperatorNameCode) {
+  static_assert(mangle(^^Interface::operator()) == "fn_NK2clEi");
+}
+
+TEST(NameManglingTest, NamesAPointerParameter) {
+  static_assert(mangle(^^Interface::set_ptr) == "fn_7set_ptrPi");
+}
+
+TEST(NameManglingTest, NamesAReferenceToALocalClassType) {
+  static_assert(mangle(^^Interface::set_widget_ref) ==
+                "fn_14set_widget_refRKN12_GLOBAL__N_16WidgetE");
+}
+
+TEST(NameManglingTest, NamesAnEnumerationParameter) {
+  static_assert(mangle(^^Interface::set_kind) ==
+                "fn_8set_kindN12_GLOBAL__N_14KindE");
+}
+
+TEST(NameManglingTest, NamesAClassTemplateSpecialisationParameter) {
+  static_assert(mangle(^^Interface::set_array) ==
+                "fn_9set_arrayN3std5arrayIiLm3EEE");
+}
+
+TEST(NameManglingTest, NamesAnIntegralNonTypeTemplateArgument) {
+  static_assert(mangle(^^Interface::set_tagged) ==
+                "fn_10set_taggedN12_GLOBAL__N_16TaggedILi3EEE");
+}
+
+TEST(NameManglingTest, DistinguishesOverloadsByParameterCount) {
+  static_assert(mangle(^^Interface::set_int) != mangle(^^Interface::set_two));
+  static_assert(mangle(^^Interface::set_two) == "fn_7set_twoii");
+}
+
+TEST(NameManglingTest, FoldsRefQualifiersIntoTheName) {
+  static_assert(mangle(^^Interface::ref_lvalue) == "fn_NR10ref_lvalueE");
+  static_assert(mangle(^^Interface::ref_rvalue) == "fn_NO10ref_rvalueE");
+  static_assert(mangle(^^Interface::ref_lvalue) !=
+                mangle(^^Interface::ref_rvalue));
+}
+
+TEST(NameManglingTest, DependsOnlyOnTheSignatureNotTheEnclosingType) {
+  static_assert(mangle(^^Interface::get) == mangle(^^Other::get));
+}
+
+}  // namespace

--- a/name_mangling_tests.cc
+++ b/name_mangling_tests.cc
@@ -16,12 +16,16 @@ enum class Kind { one, two };
 template <int N>
 struct Tagged {};
 
+template <long long N>
+struct Tagged64 {};
+
 struct Widget {};
 
 struct Interface {
   int get() const;
   void update(int value);
   int operator()(int value) const;
+  int cl(int value) const;
   void set_int(int value);
   void set_double(double value);
   void set_widget_ref(const Widget& value);
@@ -31,6 +35,8 @@ struct Interface {
   void set_array(std::array<int, 3> value);
   void set_tagged(Tagged<3> value);
   void set_negative_tagged(Tagged<-3> value);
+  void set_zero(Tagged64<0LL> value);
+  void set_big(Tagged64<4294967296LL> value);
   void ref_lvalue() &;
   void ref_rvalue() &&;
 };
@@ -40,62 +46,112 @@ struct Other {
 };
 
 TEST(NameManglingTest, NamesAConstMemberFunctionWithNoParameters) {
-  static_assert(mangle(^^Interface::get) == "fn_NK3getE");
+  static_assert(mangle(^^Interface::get) == "fn_NK3getEi");
 }
 
 TEST(NameManglingTest, NamesAMemberFunctionWithAFundamentalParameter) {
-  static_assert(mangle(^^Interface::update) == "fn_6updatei");
-  static_assert(mangle(^^Interface::set_int) == "fn_7set_inti");
-  static_assert(mangle(^^Interface::set_double) == "fn_10set_doubled");
+  static_assert(mangle(^^Interface::update) == "fn_6updatevi");
+  static_assert(mangle(^^Interface::set_int) == "fn_7set_intvi");
+  static_assert(mangle(^^Interface::set_double) == "fn_10set_doublevd");
 }
 
 TEST(NameManglingTest, NamesTheCallOperatorUsingItsOperatorNameCode) {
-  static_assert(mangle(^^Interface::operator()) == "fn_NK2clEi");
+  static_assert(mangle(^^Interface::operator()) == "fn_NKclEii");
+}
+
+TEST(NameManglingTest, CallOperatorDoesNotCollideWithAMemberLiterallyNamedCl) {
+  static_assert(mangle(^^Interface::cl) == "fn_NK2clEii");
+  static_assert(mangle(^^Interface::operator()) != mangle(^^Interface::cl));
 }
 
 TEST(NameManglingTest, NamesAPointerParameter) {
-  static_assert(mangle(^^Interface::set_ptr) == "fn_7set_ptrPi");
+  static_assert(mangle(^^Interface::set_ptr) == "fn_7set_ptrvPi");
+}
+
+TEST(NameManglingTest, NamesAnExtendedFundamentalTypeParameter) {
+  struct Interface128 {
+    void set_wide(__int128 value);
+    void set_wide_unsigned(unsigned __int128 value);
+  };
+
+  static_assert(mangle(^^Interface128::set_wide) == "fn_8set_widevn");
+  static_assert(mangle(^^Interface128::set_wide_unsigned) !=
+                mangle(^^Interface128::set_wide));
 }
 
 TEST(NameManglingTest, NamesAReferenceToALocalClassType) {
   static_assert(mangle(^^Interface::set_widget_ref) ==
-                "fn_14set_widget_refRKN12_GLOBAL__N_16WidgetE");
+                "fn_14set_widget_refvRKN12_GLOBAL__N_16WidgetE");
 }
 
 TEST(NameManglingTest, NamesAnEnumerationParameter) {
   static_assert(mangle(^^Interface::set_kind) ==
-                "fn_8set_kindN12_GLOBAL__N_14KindE");
+                "fn_8set_kindvN12_GLOBAL__N_14KindE");
 }
 
 TEST(NameManglingTest, NamesAClassTemplateSpecialisationParameter) {
   static_assert(mangle(^^Interface::set_array) ==
-                "fn_9set_arrayN3std5arrayIiLm3EEE");
+                "fn_9set_arrayvN3std5arrayIiLm3EEE");
 }
 
 TEST(NameManglingTest, NamesAnIntegralNonTypeTemplateArgument) {
   static_assert(mangle(^^Interface::set_tagged) ==
-                "fn_10set_taggedN12_GLOBAL__N_16TaggedILi3EEE");
+                "fn_10set_taggedvN12_GLOBAL__N_16TaggedILi3EEE");
 }
 
 TEST(NameManglingTest, NamesANegativeIntegralNonTypeTemplateArgument) {
   static_assert(mangle(^^Interface::set_negative_tagged) ==
-                "fn_19set_negative_taggedN12_GLOBAL__N_16TaggedILin3EEE");
+                "fn_19set_negative_taggedvN12_GLOBAL__N_16TaggedILin3EEE");
+}
+
+TEST(NameManglingTest, DoesNotTruncateA64BitNonTypeTemplateArgumentToSizeT) {
+  static_assert(mangle(^^Interface::set_zero) ==
+                "fn_8set_zerovN12_GLOBAL__N_18Tagged64ILx0EEE");
+  static_assert(mangle(^^Interface::set_big) ==
+                "fn_7set_bigvN12_GLOBAL__N_18Tagged64ILx4294967296EEE");
+  static_assert(mangle(^^Interface::set_zero) != mangle(^^Interface::set_big));
 }
 
 TEST(NameManglingTest, DistinguishesOverloadsByParameterCount) {
   static_assert(mangle(^^Interface::set_int) != mangle(^^Interface::set_two));
-  static_assert(mangle(^^Interface::set_two) == "fn_7set_twoii");
+  static_assert(mangle(^^Interface::set_two) == "fn_7set_twovii");
 }
 
 TEST(NameManglingTest, FoldsRefQualifiersIntoTheName) {
-  static_assert(mangle(^^Interface::ref_lvalue) == "fn_NR10ref_lvalueE");
-  static_assert(mangle(^^Interface::ref_rvalue) == "fn_NO10ref_rvalueE");
+  static_assert(mangle(^^Interface::ref_lvalue) == "fn_NR10ref_lvalueEv");
+  static_assert(mangle(^^Interface::ref_rvalue) == "fn_NO10ref_rvalueEv");
   static_assert(mangle(^^Interface::ref_lvalue) !=
                 mangle(^^Interface::ref_rvalue));
 }
 
 TEST(NameManglingTest, DependsOnlyOnTheSignatureNotTheEnclosingType) {
   static_assert(mangle(^^Interface::get) == mangle(^^Other::get));
+}
+
+TEST(NameManglingTest, DistinguishesMembersDifferingOnlyByReturnType) {
+  struct IntInterface {
+    int get() const;
+  };
+
+  struct LongInterface {
+    long get() const;
+  };
+
+  static_assert(mangle(^^IntInterface::get) != mangle(^^LongInterface::get));
+}
+
+TEST(NameManglingTest, DistinguishesMembersDifferingOnlyByNoexcept) {
+  struct ThrowingInterface {
+    int get() const;
+  };
+
+  struct NoexceptInterface {
+    int get() const noexcept;
+  };
+
+  static_assert(mangle(^^NoexceptInterface::get) == "fn_NK3getEDoi");
+  static_assert(mangle(^^ThrowingInterface::get) !=
+                mangle(^^NoexceptInterface::get));
 }
 
 }  // namespace

--- a/name_mangling_tests.cc
+++ b/name_mangling_tests.cc
@@ -30,6 +30,7 @@ struct Interface {
   void set_two(int value, int other);
   void set_array(std::array<int, 3> value);
   void set_tagged(Tagged<3> value);
+  void set_negative_tagged(Tagged<-3> value);
   void ref_lvalue() &;
   void ref_rvalue() &&;
 };
@@ -74,6 +75,11 @@ TEST(NameManglingTest, NamesAClassTemplateSpecialisationParameter) {
 TEST(NameManglingTest, NamesAnIntegralNonTypeTemplateArgument) {
   static_assert(mangle(^^Interface::set_tagged) ==
                 "fn_10set_taggedN12_GLOBAL__N_16TaggedILi3EEE");
+}
+
+TEST(NameManglingTest, NamesANegativeIntegralNonTypeTemplateArgument) {
+  static_assert(mangle(^^Interface::set_negative_tagged) ==
+                "fn_19set_negative_taggedN12_GLOBAL__N_16TaggedILin3EEE");
 }
 
 TEST(NameManglingTest, DistinguishesOverloadsByParameterCount) {

--- a/protocol.hh
+++ b/protocol.hh
@@ -511,14 +511,15 @@ consteval std::vector<std::meta::info> generate_vtable_specs() {
     }
     std::meta::info fn_ptr_type = substitute(^^fn_ptr_t, fn_args);
 
-    // `mangled_name_of<member>` is a `const char*`; passing it here binds
-    // through `std::string`'s pointer constructor, whose null check GCC
-    // trunk can't constant-fold under `-fsanitize=undefined` even though the
-    // pointer is never null. A prvalue binds through the move constructor,
-    // which has no such check.
+    // `std::string`'s pointer-taking constructors have a null check GCC
+    // trunk can't constant-fold under `-fsanitize=undefined`, even though
+    // `mangled_name_of<member>` is never null. The iterator-pair
+    // constructor has no such check.
+    std::string_view cached_name = mangled_name_of<member>;
     function_pointer_specs.push_back(data_member_spec(
-        fn_ptr_type, std::meta::data_member_options{
-                         .name = xyz::name_mangling::mangle(member)}));
+        fn_ptr_type,
+        std::meta::data_member_options{
+            .name = std::string(cached_name.begin(), cached_name.end())}));
   }
   return function_pointer_specs;
 }

--- a/protocol.hh
+++ b/protocol.hh
@@ -25,19 +25,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // Both `protocol` and `protocol_view` dispatch member function calls at
 // runtime through a generated vtable; `protocol`'s vtable extends
 // `protocol_view`'s with destroy/copy/move entries used for allocator-aware
-// ownership.
+// ownership. Vtable entries are named by mangling the interface member
+// function's signature (see "name_mangling.h"), so an entry can be found by
+// the signature it implements rather than by declaration order.
 //
 // Neither implementation currently supports operators other than operator().
 
 #include <algorithm>
 #include <cassert>
-#include <charconv>
 #include <concepts>
 #include <cstddef>
 #include <functional>
-#include <limits>
 #include <memory>
 #include <meta>
+#include <optional>
 #include <ranges>
 #include <span>
 #include <string>
@@ -45,6 +46,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <type_traits>
 #include <utility>
 #include <vector>
+
+#include "name_mangling.h"
 
 namespace xyz::reflection {
 
@@ -96,11 +99,6 @@ consteval bool same_name(std::meta::info a, std::meta::info b) {
     return is_call_operator(a) && is_call_operator(b);
   return has_identifier(a) && has_identifier(b) &&
          identifier_of(a) == identifier_of(b);
-}
-
-// A valid identifier for `member`, for naming generated vtable entries.
-consteval std::string_view member_name(std::meta::info member) {
-  return is_call_operator(member) ? "call_operator" : identifier_of(member);
 }
 
 // Returns `true` if the member functions `candidate` and `interface` have
@@ -178,20 +176,26 @@ constexpr inline auto conformance_candidates_of =
 
 // The non-static members of `conformance_candidates_of<Type>`: the member
 // functions an interface `Type` requires. Overloads appear as separate
-// entries; an entry's index identifies its vtable slot.
+// entries, each naming its own vtable entry (see
+// `xyz::name_mangling::mangle`).
 template <std::meta::info Type>
 constexpr inline auto protocol_interface_functions_of =
     std::define_static_array(
         conformance_candidates_of<Type> |
         std::views::filter(std::not_fn(std::meta::is_static_member)));
 
-// The vtable entry for the interface member function at `Index`;
-// `generate_vtable_specs` declares one entry per interface member function in
-// the same order as `protocol_interface_functions_of`.
-template <std::meta::info VtableType, std::size_t Index>
-consteval std::meta::info vtable_entry_at() {
-  return nonstatic_data_members_of(
-      VtableType, std::meta::access_context::unprivileged())[Index];
+// The entry of `VtableType` named by the mangled signature of the interface
+// member function `member`, if it declares one.
+template <std::meta::info VtableType>
+consteval std::optional<std::meta::info> find_vtable_entry(
+    std::meta::info member) {
+  std::string name = xyz::name_mangling::mangle(member);
+  std::vector<std::meta::info> entries = nonstatic_data_members_of(
+      VtableType, std::meta::access_context::unprivileged());
+  for (std::meta::info entry : entries) {
+    if (identifier_of(entry) == name) return entry;
+  }
+  return std::nullopt;
 }
 
 // Vanishing-this-pointer thunk for one overload of a synthesised member
@@ -201,17 +205,18 @@ consteval std::meta::info vtable_entry_at() {
 // of the Interface type. `member_thunk` combines the thunks for all
 // overloads of a name into one overload set.
 template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
-          typename Vtable, std::size_t Index, bool IsConst, bool IsNoexcept>
+          typename Vtable, std::meta::info Member, bool IsConst,
+          bool IsNoexcept>
 struct method_thunk;
 
 // TODO(jbcoe): Extend this approach to handle lvalue and rvalue qualifiers.
 template <typename R, typename... Args, typename EnclosingType,
-          typename ProtocolType, typename Vtable, std::size_t Index,
+          typename ProtocolType, typename Vtable, std::meta::info Member,
           bool IsConst, bool IsNoexcept>
-struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Index,
+struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Member,
                     IsConst, IsNoexcept> {
   static constexpr std::meta::info vtable_entry =
-      vtable_entry_at<^^Vtable, Index>();
+      *find_vtable_entry<^^Vtable>(Member);
 
   // Recovers the EnclosingType pointer: `call_operator_base` derives from
   // this thunk, while a generated `member_base` holds it as its sole data
@@ -265,9 +270,10 @@ struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Index,
 template <bool Noexcept, typename R, typename... Args>
 using fn_ptr_t = R (*)(Args...) noexcept(Noexcept);
 
-// One overload of a synthesised member function: the interface member, its
-// vtable slot and the const-qualification of the generated wrapper.
-template <std::meta::info Member, std::size_t Index, bool IsConst>
+// One overload of a synthesised member function: the interface member (which
+// names its vtable entry) and the const-qualification of the generated
+// wrapper.
+template <std::meta::info Member, bool IsConst>
 struct overload_spec {};
 
 // The `method_thunk` specialisation for an `overload_spec`.
@@ -275,9 +281,9 @@ template <typename Spec, typename EnclosingType, typename ProtocolType,
           typename Vtable>
 struct method_thunk_for;
 
-template <std::meta::info Member, std::size_t Index, bool IsConst,
-          typename EnclosingType, typename ProtocolType, typename Vtable>
-struct method_thunk_for<overload_spec<Member, Index, IsConst>, EnclosingType,
+template <std::meta::info Member, bool IsConst, typename EnclosingType,
+          typename ProtocolType, typename Vtable>
+struct method_thunk_for<overload_spec<Member, IsConst>, EnclosingType,
                         ProtocolType, Vtable> {
   // Build the function-pointer type R(*)(Args...) from the method's return
   // type and parameter types.
@@ -292,7 +298,7 @@ struct method_thunk_for<overload_spec<Member, Index, IsConst>, EnclosingType,
   // clang-format off
   using type = typename[:substitute(
       ^^method_thunk, {fn_ptr_type(), ^^EnclosingType, ^^ProtocolType, ^^Vtable,
-                       std::meta::reflect_constant(Index),
+                       std::meta::reflect_constant(Member),
                        std::meta::reflect_constant(IsConst),
                        std::meta::reflect_constant(is_noexcept(Member))}):];
   // clang-format on
@@ -426,8 +432,7 @@ consteval std::meta::info generate_wrapper_bases() {
     names_generated.push_back(first);
 
     std::vector<std::meta::info> specs;
-    for (std::size_t index = 0; index < members.size(); ++index) {
-      std::meta::info member = members[index];
+    for (std::meta::info member : members) {
       if (!same_name(member, first) ||
           !generates_wrapper_for<ConstPolicy>(member, members))
         continue;
@@ -436,7 +441,6 @@ consteval std::meta::info generate_wrapper_bases() {
       // clang-format off
       specs.push_back(substitute(
           ^^overload_spec, {reflect_constant(member),
-                            std::meta::reflect_constant(index),
                             std::meta::reflect_constant(wrapper_is_const)}));
       // clang-format on
     }
@@ -466,31 +470,17 @@ using protocol_wrappers_t =
     typename[:generate_wrapper_bases<^^T, ProtocolType, Vtable,
                                      ConstPolicy>():];
 
-// Names the vtable entry for the interface member function at `index`.
-// Overloads share an identifier, so the index keeps entry names unique.
-consteval std::string vtable_entry_name(std::meta::info member,
-                                        std::size_t index) {
-  char digits[std::numeric_limits<std::size_t>::digits10 + 1];
-  auto [end, error] = std::to_chars(digits, digits + sizeof(digits), index);
-  std::string name(member_name(member));
-  name += '_';
-  name.append(digits, end);
-  return name;
-}
-
 // Returns a list of data_member_spec values, one for each member function
 // implemented by `protocol`, each describing a vtable function pointer with
 // signature R(*)(void*, Args...) for a mutable interface method, or
-// R(*)(const void*, Args...) for a const one.
+// R(*)(const void*, Args...) for a const one, named by the member function's
+// mangled signature (see `xyz::name_mangling::mangle`).
 template <std::meta::info interface_type>
 consteval std::vector<std::meta::info> generate_vtable_specs() {
   std::vector<std::meta::info> function_pointer_specs;
 
-  std::span<const std::meta::info> members =
-      protocol_interface_functions_of<interface_type>;
-  for (std::size_t index = 0; index < members.size(); ++index) {
-    std::meta::info member = members[index];
-
+  for (std::meta::info member :
+       protocol_interface_functions_of<interface_type>) {
     // Build the function-pointer type R(*)(void*, Args...) noexcept(...)
     // from the method's return type, parameter types and noexcept-ness; a
     // const method takes `const void*` instead, matching the constness of
@@ -507,7 +497,7 @@ consteval std::vector<std::meta::info> generate_vtable_specs() {
 
     function_pointer_specs.push_back(data_member_spec(
         fn_ptr_type, std::meta::data_member_options{
-                         .name = vtable_entry_name(member, index)}));
+                         .name = xyz::name_mangling::mangle(member)}));
   }
   return function_pointer_specs;
 }
@@ -575,13 +565,10 @@ consteval typename vtable_generator<T>::vtable make_view_vtable() {
   using Vtable = typename vtable_generator<T>::vtable;
   Vtable result{};
 
-  constexpr std::span<const std::meta::info> members =
-      protocol_interface_functions_of<^^T>;
-  template for (constexpr std::size_t index :
-                std::views::iota(std::size_t{0}, members.size())) {
-    constexpr std::meta::info member = members[index];
+  template for (constexpr std::meta::info member :
+                protocol_interface_functions_of<^^T>) {
     constexpr std::meta::info vtable_member =
-        vtable_entry_at<^^Vtable, index>();
+        *find_vtable_entry<^^Vtable>(member);
     using FnPtrType = typename[:type_of(vtable_member):];
     if constexpr (is_const(member)) {
       constexpr std::meta::info candidate =
@@ -754,7 +741,8 @@ class protocol
   // Grants the synthesised member thunks access to `object_`/`vtable_` so
   // they can locate and call through the matching vtable entry.
   template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
-            typename Vtable, std::size_t Index, bool IsConst, bool IsNoexcept>
+            typename Vtable, std::meta::info Member, bool IsConst,
+            bool IsNoexcept>
   friend struct detail::method_thunk;
 
   [[no_unique_address]] Alloc alloc_;
@@ -983,7 +971,8 @@ class protocol_view
   // Grants the synthesised member thunks access to `object_`/`vtable_` so
   // they can locate and call through the matching vtable entry.
   template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
-            typename Vtable, std::size_t Index, bool IsConst, bool IsNoexcept>
+            typename Vtable, std::meta::info Member, bool IsConst,
+            bool IsNoexcept>
   friend struct detail::method_thunk;
 
   // Non-owning pointer to the viewed object.
@@ -1029,7 +1018,8 @@ class protocol_view<const T> : public detail::protocol_wrappers_t<
   // Grants the synthesised member thunks access to `object_`/`vtable_` so
   // they can locate and call through the matching vtable entry.
   template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
-            typename Vtable, std::size_t Index, bool IsConst, bool IsNoexcept>
+            typename Vtable, std::meta::info Member, bool IsConst,
+            bool IsNoexcept>
   friend struct detail::method_thunk;
 
   // Non-owning pointer to the viewed object.

--- a/protocol.hh
+++ b/protocol.hh
@@ -38,9 +38,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <functional>
 #include <memory>
 #include <meta>
-#include <optional>
 #include <ranges>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -184,18 +184,24 @@ constexpr inline auto protocol_interface_functions_of =
         conformance_candidates_of<Type> |
         std::views::filter(std::not_fn(std::meta::is_static_member)));
 
+// The mangled name of `Member`, computed once per distinct `Member` and
+// reused by every vtable this member is looked up against.
+template <std::meta::info Member>
+constexpr inline const char* mangled_name_of =
+    std::define_static_string(xyz::name_mangling::mangle(Member));
+
 // The entry of `VtableType` named by the mangled signature of the interface
-// member function `member`, if it declares one.
-template <std::meta::info VtableType>
-consteval std::optional<std::meta::info> find_vtable_entry(
-    std::meta::info member) {
-  std::string name = xyz::name_mangling::mangle(member);
+// member function `Member`.
+template <std::meta::info VtableType, std::meta::info Member>
+consteval std::meta::info find_vtable_entry() {
+  std::string_view name = mangled_name_of<Member>;
   std::vector<std::meta::info> entries = nonstatic_data_members_of(
       VtableType, std::meta::access_context::unprivileged());
   for (std::meta::info entry : entries) {
     if (identifier_of(entry) == name) return entry;
   }
-  return std::nullopt;
+  throw std::runtime_error("find_vtable_entry: no entry named '" +
+                           std::string(name) + "'");
 }
 
 // Vanishing-this-pointer thunk for one overload of a synthesised member
@@ -216,7 +222,7 @@ template <typename R, typename... Args, typename EnclosingType,
 struct method_thunk<R (*)(Args...), EnclosingType, ProtocolType, Vtable, Member,
                     IsConst, IsNoexcept> {
   static constexpr std::meta::info vtable_entry =
-      *find_vtable_entry<^^Vtable>(Member);
+      find_vtable_entry<^^Vtable, Member>();
 
   // Recovers the EnclosingType pointer: `call_operator_base` derives from
   // this thunk, while a generated `member_base` holds it as its sole data
@@ -489,8 +495,8 @@ template <std::meta::info interface_type>
 consteval std::vector<std::meta::info> generate_vtable_specs() {
   std::vector<std::meta::info> function_pointer_specs;
 
-  for (std::meta::info member :
-       protocol_interface_functions_of<interface_type>) {
+  template for (constexpr std::meta::info member :
+                protocol_interface_functions_of<interface_type>) {
     // Build the function-pointer type R(*)(void*, Args...) noexcept(...)
     // from the method's return type, parameter types and noexcept-ness; a
     // const method takes `const void*` instead, matching the constness of
@@ -506,8 +512,8 @@ consteval std::vector<std::meta::info> generate_vtable_specs() {
     std::meta::info fn_ptr_type = substitute(^^fn_ptr_t, fn_args);
 
     function_pointer_specs.push_back(data_member_spec(
-        fn_ptr_type, std::meta::data_member_options{
-                         .name = xyz::name_mangling::mangle(member)}));
+        fn_ptr_type,
+        std::meta::data_member_options{.name = mangled_name_of<member>}));
   }
   return function_pointer_specs;
 }
@@ -578,7 +584,7 @@ consteval typename vtable_generator<T>::vtable make_view_vtable() {
   template for (constexpr std::meta::info member :
                 protocol_interface_functions_of<^^T>) {
     constexpr std::meta::info vtable_member =
-        *find_vtable_entry<^^Vtable>(member);
+        find_vtable_entry<^^Vtable, member>();
     using FnPtrType = typename[:type_of(vtable_member):];
     if constexpr (is_const(member)) {
       constexpr std::meta::info candidate =

--- a/protocol.hh
+++ b/protocol.hh
@@ -511,9 +511,14 @@ consteval std::vector<std::meta::info> generate_vtable_specs() {
     }
     std::meta::info fn_ptr_type = substitute(^^fn_ptr_t, fn_args);
 
+    // `mangled_name_of<member>` is a `const char*`; passing it here binds
+    // through `std::string`'s pointer constructor, whose null check GCC
+    // trunk can't constant-fold under `-fsanitize=undefined` even though the
+    // pointer is never null. A prvalue binds through the move constructor,
+    // which has no such check.
     function_pointer_specs.push_back(data_member_spec(
-        fn_ptr_type,
-        std::meta::data_member_options{.name = mangled_name_of<member>}));
+        fn_ptr_type, std::meta::data_member_options{
+                         .name = xyz::name_mangling::mangle(member)}));
   }
   return function_pointer_specs;
 }

--- a/protocol.hh
+++ b/protocol.hh
@@ -187,7 +187,7 @@ constexpr inline auto protocol_interface_functions_of =
 // The mangled name of `Member`, computed once per distinct `Member` and
 // reused by every vtable this member is looked up against.
 template <std::meta::info Member>
-constexpr inline const char* mangled_name_of =
+constexpr inline auto mangled_name_of =
     std::define_static_string(xyz::name_mangling::mangle(Member));
 
 // The entry of `VtableType` named by the mangled signature of the interface


### PR DESCRIPTION
Closes #254 

The name mangler intentionally duplicates and extends the name mangling logic from the tutorial `tutorials/advanced_vtables.cc`.

Some parameter types are intentionally unsupported. Using unsupported types as parameters will fail noisily rather than result in failed conformance checks or odd behaviour at runtime.