### PR TITLE
Reject ref-qualified interface member functions

### DIFF
--- a/protocol.hh
+++ b/protocol.hh
@@ -177,12 +177,30 @@ constexpr inline auto conformance_candidates_of =
 // The non-static members of `conformance_candidates_of<Type>`: the member
 // functions an interface `Type` requires. Overloads appear as separate
 // entries, each naming its own vtable entry (see
-// `xyz::name_mangling::mangle`).
+// `xyz::name_mangling::mangle`). Ref-qualified members are rejected: the
+// synthesised thunks call the target on an lvalue and cannot forward the
+// protocol object's value category (see the TODO on `method_thunk`).
+template <std::meta::info Type>
+consteval std::vector<std::meta::info> protocol_interface_function_infos() {
+  std::vector<std::meta::info> result;
+  for (std::meta::info member : conformance_candidates_of<Type>) {
+    if (is_static_member(member)) continue;
+    if (is_lvalue_reference_qualified(member) ||
+        is_rvalue_reference_qualified(member)) {
+      std::string name = has_identifier(member)
+                             ? std::string(identifier_of(member))
+                             : "operator()";
+      throw std::runtime_error("ref-qualified member function '" + name +
+                               "' is not supported in a protocol interface");
+    }
+    result.push_back(member);
+  }
+  return result;
+}
+
 template <std::meta::info Type>
 constexpr inline auto protocol_interface_functions_of =
-    std::define_static_array(
-        conformance_candidates_of<Type> |
-        std::views::filter(std::not_fn(std::meta::is_static_member)));
+    std::define_static_array(protocol_interface_function_infos<Type>());
 
 // The mangled name of `Member`, computed once per distinct `Member` and
 // reused by every vtable this member is looked up against.
@@ -215,7 +233,9 @@ template <typename FnPtrType, typename EnclosingType, typename ProtocolType,
           bool IsNoexcept>
 struct method_thunk;
 
-// TODO(jbcoe): Extend this approach to handle lvalue and rvalue qualifiers.
+// TODO(jbcoe): Extend this approach to handle lvalue and rvalue qualifiers;
+// until then `protocol_interface_function_infos` rejects ref-qualified
+// interface members.
 template <typename R, typename... Args, typename EnclosingType,
           typename ProtocolType, typename Vtable, std::meta::info Member,
           bool IsConst, bool IsNoexcept>
@@ -629,8 +649,12 @@ consteval bool is_protocol_conformant() {
   // Checking for protocol interface conformance is O(N*M) over member counts,
   // assumed to be negligible at compile time.
   // TODO(jbcoe): Use set/map once there is library support for `constexpr`.
+  // Calls `protocol_interface_function_infos` rather than reading
+  // `protocol_interface_functions_of` so that the rejection of a
+  // ref-qualified interface member is thrown from this function, where a
+  // caller can catch it, instead of escaping a variable initializer.
   auto interface_member_functions =
-      detail::protocol_interface_functions_of<^^Interface>;
+      detail::protocol_interface_function_infos<^^Interface>();
   auto candidate_member_functions =
       detail::conformance_candidates_of<^^Candidate>;
 

--- a/protocol_test.cc
+++ b/protocol_test.cc
@@ -7,6 +7,7 @@
 
 #include <concepts>
 #include <cstddef>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -333,6 +334,19 @@ TEST(ReflectionProtocolTest, CopiesAreIndependentObjects) {
 // Conformance check tests.
 // ---------------------------------------------------------------------------
 
+// Returns `true` if checking conformance of `Candidate` against `Interface`
+// throws during constant evaluation, as it does for a ref-qualified
+// interface member function.
+template <typename Interface, typename Candidate>
+consteval bool conformance_check_rejects() {
+  try {
+    (void)is_protocol_conformant<Interface, Candidate>();
+  } catch (const std::runtime_error&) {
+    return true;
+  }
+  return false;
+}
+
 TEST(ConformsToTest, EmptyInterfaceIsAlwaysSatisfied) {
   struct EmptyInterface {};
 
@@ -487,34 +501,20 @@ TEST(ConformsToTest, NonNoexceptInterfaceAcceptsNoexceptCandidate) {
   static_assert(is_protocol_conformant<Interface, NoexceptCandidate>());
 }
 
-TEST(ConformsToTest, LvalueRefQualifierMustMatch) {
-  struct Interface {
+TEST(ConformsToTest, RefQualifiedInterfaceMembersAreRejected) {
+  struct LvalueRefInterface {
     void f() &;
   };
 
-  struct Conforming {
+  struct RvalueRefInterface {
+    void f() &&;
+  };
+
+  struct MatchingLvalueRefCandidate {
     void f() &;
   };
 
-  struct UnqualifiedCandidate {
-    void f();
-  };
-
-  struct RvalueRefCandidate {
-    void f() &&;
-  };
-
-  static_assert(is_protocol_conformant<Interface, Conforming>());
-  static_assert(!is_protocol_conformant<Interface, UnqualifiedCandidate>());
-  static_assert(!is_protocol_conformant<Interface, RvalueRefCandidate>());
-}
-
-TEST(ConformsToTest, RvalueRefQualifierMustMatch) {
-  struct Interface {
-    void f() &&;
-  };
-
-  struct Conforming {
+  struct MatchingRvalueRefCandidate {
     void f() &&;
   };
 
@@ -522,13 +522,14 @@ TEST(ConformsToTest, RvalueRefQualifierMustMatch) {
     void f();
   };
 
-  struct LvalueRefCandidate {
-    void f() &;
-  };
-
-  static_assert(is_protocol_conformant<Interface, Conforming>());
-  static_assert(!is_protocol_conformant<Interface, UnqualifiedCandidate>());
-  static_assert(!is_protocol_conformant<Interface, LvalueRefCandidate>());
+  static_assert(conformance_check_rejects<LvalueRefInterface,
+                                          MatchingLvalueRefCandidate>());
+  static_assert(
+      conformance_check_rejects<LvalueRefInterface, UnqualifiedCandidate>());
+  static_assert(conformance_check_rejects<RvalueRefInterface,
+                                          MatchingRvalueRefCandidate>());
+  static_assert(
+      conformance_check_rejects<RvalueRefInterface, UnqualifiedCandidate>());
 }
 
 TEST(ConformsToTest, UnqualifiedInterfaceDoesNotMatchRefQualifiedCandidate) {
@@ -726,19 +727,16 @@ TEST(ConformsToTest, StaticCandidateConformsToNonConstMember) {
   static_assert(is_protocol_conformant<Interface, Conforming>());
 }
 
-TEST(ConformsToTest, StaticCandidateConformsToRefQualifiedMember) {
+TEST(ConformsToTest, RefQualifiedInterfaceMemberRejectedForStaticCandidate) {
   struct Interface {
-    int get() &;
     int take() &&;
   };
 
   struct Conforming {
-    static int get();
-
     static int take();
   };
 
-  static_assert(is_protocol_conformant<Interface, Conforming>());
+  static_assert(conformance_check_rejects<Interface, Conforming>());
 }
 
 TEST(ConformsToTest, StaticCandidateWithWrongSignatureDoesNotConform) {


### PR DESCRIPTION
Ref-qualified interface members conformed, but the synthesised thunks call the target on an lvalue and cannot forward the protocol object's value category: `std::move(p).take()` would call `take() &&` on an lvalue. Reject them when enumerating interface member functions, until the thunks forward value categories.

`is_protocol_conformant` throws the rejection from the function itself so a consteval caller can catch it; instantiating `protocol<I>`/`protocol_view<I>` with a ref-qualified interface member remains a hard error.

Closes #230.