### PR TITLE
Allows protocol_view (for T and const T) to be constructed implicitly.

### DIFF
--- a/protocol.hh
+++ b/protocol.hh
@@ -1008,21 +1008,25 @@ class protocol_view
   protocol_view& operator=(protocol_view&&) noexcept = default;
   ~protocol_view() = default;
 
-  // Construct from any non-const type U that conforms to the Interface T.
+  // Views a non-const object that conforms to the Interface T. Implicit
+  // because the lvalue-reference parameter already rejects temporaries, so a
+  // view can never outlive what it views.
   template <typename U>
     requires is_protocol_conformant_v<T, std::remove_cvref_t<U>> &&
                  (!is_protocol_view_v<std::remove_cvref_t<U>>) &&
                  (!std::is_const_v<U>)
-  explicit protocol_view(U& object)
+  protocol_view(U& object)
       : object_(static_cast<void*>(std::addressof(object))),
         vtable_(
             &detail::view_vtable_for<T, U, detail::const_policy::all_const>) {}
 
-  // Views the object a `protocol<T>` owns, sharing its vtable.
+  // Views the object a `protocol<T>` owns, sharing its vtable. Implicit
+  // because a view is a non-owning handle and the deleted rvalue overload
+  // below rejects temporaries, so nothing can dangle.
   //
   // Precondition: `p` is not valueless.
   template <typename Alloc>
-  explicit protocol_view(protocol<T, Alloc>& p) noexcept
+  protocol_view(protocol<T, Alloc>& p) noexcept
       : object_(p.object_), vtable_(p.vtable_) {}
 
   // A view of a temporary would dangle.
@@ -1071,21 +1075,30 @@ class protocol_view<const T> : public detail::protocol_wrappers_t<
   protocol_view& operator=(protocol_view&&) noexcept = default;
   ~protocol_view() = default;
 
-  // Construct from any (possibly const) type U that conforms to the
-  // Interface T.
+  // Views a (possibly const) object that conforms to the Interface T.
   template <typename U>
     requires is_protocol_conformant_v<T, std::remove_cvref_t<U>> &&
                  (!is_protocol_view_v<std::remove_cvref_t<U>>)
-  explicit protocol_view(const U& object)
+  protocol_view(const U& object)
       : object_(static_cast<const void*>(std::addressof(object))),
         vtable_(
             &detail::view_vtable_for<T, U, detail::const_policy::const_only>) {}
 
-  // Views the object a `protocol<T>` owns, sharing its vtable.
+  // A view of a temporary would dangle. Unlike the mutable view, this
+  // constructor's const-reference parameter would otherwise bind an rvalue,
+  // so a deleted overload rejects them.
+  template <typename U>
+    requires is_protocol_conformant_v<T, std::remove_cvref_t<U>> &&
+                 (!is_protocol_view_v<std::remove_cvref_t<U>>)
+  protocol_view(const U&&) = delete;
+
+  // Views the object a `protocol<T>` owns, sharing its vtable. Implicit
+  // because a view is a non-owning handle and the deleted rvalue overload
+  // below rejects temporaries, so nothing can dangle.
   //
   // Precondition: `p` is not valueless.
   template <typename Alloc>
-  explicit protocol_view(const protocol<T, Alloc>& p) noexcept
+  protocol_view(const protocol<T, Alloc>& p) noexcept
       : object_(p.object_), vtable_(p.vtable_) {}
 
   // A view of a temporary would dangle.

--- a/protocol.hh
+++ b/protocol.hh
@@ -1008,9 +1008,7 @@ class protocol_view
   protocol_view& operator=(protocol_view&&) noexcept = default;
   ~protocol_view() = default;
 
-  // Views a non-const object that conforms to the Interface T. Implicit
-  // because the lvalue-reference parameter already rejects temporaries, so a
-  // view can never outlive what it views.
+  // Views a non-const object that conforms to the Interface T.
   template <typename U>
     requires is_protocol_conformant_v<T, std::remove_cvref_t<U>> &&
                  (!is_protocol_view_v<std::remove_cvref_t<U>>) &&
@@ -1020,9 +1018,7 @@ class protocol_view
         vtable_(
             &detail::view_vtable_for<T, U, detail::const_policy::all_const>) {}
 
-  // Views the object a `protocol<T>` owns, sharing its vtable. Implicit
-  // because a view is a non-owning handle and the deleted rvalue overload
-  // below rejects temporaries, so nothing can dangle.
+  // Views the object a `protocol<T>` owns, sharing its vtable.
   //
   // Precondition: `p` is not valueless.
   template <typename Alloc>
@@ -1084,17 +1080,13 @@ class protocol_view<const T> : public detail::protocol_wrappers_t<
         vtable_(
             &detail::view_vtable_for<T, U, detail::const_policy::const_only>) {}
 
-  // A view of a temporary would dangle. Unlike the mutable view, this
-  // constructor's const-reference parameter would otherwise bind an rvalue,
-  // so a deleted overload rejects them.
+  // A view of a temporary would dangle.
   template <typename U>
     requires is_protocol_conformant_v<T, std::remove_cvref_t<U>> &&
                  (!is_protocol_view_v<std::remove_cvref_t<U>>)
   protocol_view(const U&&) = delete;
 
-  // Views the object a `protocol<T>` owns, sharing its vtable. Implicit
-  // because a view is a non-owning handle and the deleted rvalue overload
-  // below rejects temporaries, so nothing can dangle.
+  // Views the object a `protocol<T>` owns, sharing its vtable.
   //
   // Precondition: `p` is not valueless.
   template <typename Alloc>

--- a/protocol_test.cc
+++ b/protocol_test.cc
@@ -897,8 +897,12 @@ TEST(ReflectionProtocolViewTest, IsConstructibleFromConformingType) {
   // protocol_view's constructor takes U&, so constructibility is checked
   // from an lvalue, not a prvalue.
   static_assert(std::is_constructible_v<protocol_view<Interface>, Conforming&>);
+  static_assert(std::is_convertible_v<Conforming&, protocol_view<Interface>>);
   static_assert(
       !std::is_constructible_v<protocol_view<Interface>, NonConforming&>);
+  // A view of a temporary would dangle; the lvalue-reference parameter
+  // rejects one.
+  static_assert(!std::is_constructible_v<protocol_view<Interface>, Conforming>);
 }
 
 TEST(ReflectionProtocolViewTest, NotConstructibleFromConstObject) {
@@ -934,8 +938,18 @@ TEST(ReflectionProtocolViewTest, ConstViewIsConstructibleFromConstObject) {
                                         const Conforming&>);
   static_assert(
       std::is_constructible_v<protocol_view<const Interface>, Conforming&>);
+  static_assert(
+      std::is_convertible_v<const Conforming&, protocol_view<const Interface>>);
+  static_assert(
+      std::is_convertible_v<Conforming&, protocol_view<const Interface>>);
   static_assert(!std::is_constructible_v<protocol_view<const Interface>,
                                          const NonConforming&>);
+  // A view of a temporary would dangle; the deleted rvalue overload rejects
+  // one even though the const-reference constructor would otherwise bind it.
+  static_assert(
+      !std::is_constructible_v<protocol_view<const Interface>, Conforming>);
+  static_assert(!std::is_constructible_v<protocol_view<const Interface>,
+                                         const Conforming>);
 }
 
 TEST(ReflectionProtocolTest, IsConstructibleInPlaceFromConformingType) {
@@ -2247,6 +2261,8 @@ TEST(ReflectionProtocolViewTest, IsConstructibleFromProtocol) {
 
   static_assert(
       std::is_constructible_v<protocol_view<Interface>, protocol<Interface>&>);
+  static_assert(
+      std::is_convertible_v<protocol<Interface>&, protocol_view<Interface>>);
   static_assert(!std::is_constructible_v<protocol_view<Interface>,
                                          const protocol<Interface>&>);
   static_assert(
@@ -2262,6 +2278,10 @@ TEST(ReflectionProtocolViewTest, ConstViewIsConstructibleFromProtocol) {
                                         const protocol<Interface>&>);
   static_assert(std::is_constructible_v<protocol_view<const Interface>,
                                         protocol<Interface>&>);
+  static_assert(std::is_convertible_v<const protocol<Interface>&,
+                                      protocol_view<const Interface>>);
+  static_assert(std::is_convertible_v<protocol<Interface>&,
+                                      protocol_view<const Interface>>);
   static_assert(!std::is_constructible_v<protocol_view<const Interface>,
                                          protocol<Interface>>);
   static_assert(!std::is_constructible_v<protocol_view<const Interface>,
@@ -2422,7 +2442,7 @@ TEST(ReflectionProtocolViewTest, ViewOfProtocolPassedByValue) {
   auto read = [](protocol_view<const Interface> view) { return view.get(); };
 
   protocol<Interface> p(Conforming{5});
-  EXPECT_EQ(read(protocol_view<const Interface>(p)), 5);
+  EXPECT_EQ(read(p), 5);
 }
 
 }  // namespace

--- a/protocol_test.cc
+++ b/protocol_test.cc
@@ -900,8 +900,7 @@ TEST(ReflectionProtocolViewTest, IsConstructibleFromConformingType) {
   static_assert(std::is_convertible_v<Conforming&, protocol_view<Interface>>);
   static_assert(
       !std::is_constructible_v<protocol_view<Interface>, NonConforming&>);
-  // A view of a temporary would dangle; the lvalue-reference parameter
-  // rejects one.
+  // A view of a temporary would dangle.
   static_assert(!std::is_constructible_v<protocol_view<Interface>, Conforming>);
 }
 
@@ -944,8 +943,7 @@ TEST(ReflectionProtocolViewTest, ConstViewIsConstructibleFromConstObject) {
       std::is_convertible_v<Conforming&, protocol_view<const Interface>>);
   static_assert(!std::is_constructible_v<protocol_view<const Interface>,
                                          const NonConforming&>);
-  // A view of a temporary would dangle; the deleted rvalue overload rejects
-  // one even though the const-reference constructor would otherwise bind it.
+  // A view of a temporary would dangle.
   static_assert(
       !std::is_constructible_v<protocol_view<const Interface>, Conforming>);
   static_assert(!std::is_constructible_v<protocol_view<const Interface>,


### PR DESCRIPTION
Constructing a `protocol_view` is now implicit, so a `protocol` or a conforming object converts to a view wherever one is expected without an explicit cast.

Adds deleted constructors to avoid constructing views from temporaries.