### PR TITLE
Exclude types with base classes from the maybe-lambda fallback

### DIFF
--- a/protocol.hh
+++ b/protocol.hh
@@ -79,19 +79,18 @@ namespace detail {
 
 // Per ISO C++ ([expr.prim.lambda.closure]), closure types are unique, unnamed,
 // non-union class types.
+// The closure type is not an aggregate type.
 // This concept will also match an unnamed class type with a single
 // `operator()`.
-// TODO(jbcoe): Refine this concept to match only lambdas.
 //
-// Base classes are excluded: a closure type has none, and a class template
-// specialization also has no identifier, so without this `protocol<I>` and
-// `protocol_view<I>` would match when `I` has a single call operator —
-// their `operator()` is a wrapper-base member brought in by a
-// using-declaration, whose reflection clang-p2996 rejects
-// (https://github.com/bloomberg/clang-p2996/issues/342).
+// In practice a lambda has no base classes and no template arguments, although
+// there is no wording in the standard to guarantee this.
+//
+// TODO(jbcoe): Refine this concept to match only lambdas.
 template <typename T>
 concept is_maybe_lambda =
     is_class_type(dealias(^^T)) && !has_identifier(dealias(^^T)) &&
+    !is_aggregate(dealias(^^T)) && !has_template_arguments(dealias(^^T)) &&
     bases_of(dealias(^^T), std::meta::access_context::unprivileged()).empty() &&
     requires { &T::operator(); };
 

--- a/protocol.hh
+++ b/protocol.hh
@@ -82,9 +82,16 @@ namespace detail {
 // This concept will also match an unnamed class type with a single
 // `operator()`.
 // TODO(jbcoe): Refine this concept to match only lambdas.
+//
+// Base classes are excluded: a closure type has none, and a class template
+// specialization also has no identifier, so without this `protocol<I>` and
+// `protocol_view<I>` would match when `I` has a single call operator —
+// their `operator()` is a wrapper-base member brought in by a
+// using-declaration, whose reflection clang-p2996 rejects.
 template <typename T>
 concept is_maybe_lambda =
     is_class_type(dealias(^^T)) && !has_identifier(dealias(^^T)) &&
+    bases_of(dealias(^^T), std::meta::access_context::unprivileged()).empty() &&
     requires { &T::operator(); };
 
 consteval bool is_call_operator(std::meta::info function) {

--- a/protocol.hh
+++ b/protocol.hh
@@ -87,7 +87,8 @@ namespace detail {
 // specialization also has no identifier, so without this `protocol<I>` and
 // `protocol_view<I>` would match when `I` has a single call operator —
 // their `operator()` is a wrapper-base member brought in by a
-// using-declaration, whose reflection clang-p2996 rejects.
+// using-declaration, whose reflection clang-p2996 rejects
+// (https://github.com/bloomberg/clang-p2996/issues/342).
 template <typename T>
 concept is_maybe_lambda =
     is_class_type(dealias(^^T)) && !has_identifier(dealias(^^T)) &&


### PR DESCRIPTION
clang-tidy fails on `main` since #244: its view-constructor constraint evaluates `is_protocol_conformant_v<I, protocol<I>>`, and when `I` has a single call operator, `protocol<I>` matches `is_maybe_lambda` (a class template specialization has no identifier), so the lambda fallback reflects `protocol`'s wrapper-base `operator()` — a using-declarator reflection clang-p2996 rejects where GCC trunk accepts it. The rejection looks like rejects-valid and is reported upstream as bloomberg/clang-p2996#342, tracked here by #277.

Closure types have no base classes, so requiring an empty `bases_of` keeps lambdas matched and excludes `protocol` and `protocol_view` from the fallback. No conformance results change, and the exclusion remains a correct refinement of the concept even once the upstream fix lands.
