### PR TITLE
Wait for both coverage uploads before notifying

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+codecov:
+  notify:
+    # Two uploads per commit (runtime and consteval flags); wait for both
+    # before comparing against the base, or the first one fails the status.
+    after_n_builds: 2
+
 ignore:
   - "*_test.cc"
   - "*_tests.cc"


### PR DESCRIPTION
Codecov posts the project status after the first upload, so the runtime-only report is compared against a base that also carries the consteval flag and fails the 1% threshold (seen on #282). Set `after_n_builds: 2` so the comparison waits for both uploads.