### PR TITLE
Delete rvalue constructor on protocol_view<T>

### DIFF
--- a/protocol.hh
+++ b/protocol.hh
@@ -1061,6 +1061,13 @@ class protocol_view
         vtable_(
             &detail::view_vtable_for<T, U, detail::const_policy::all_const>) {}
 
+  // A view of a temporary would dangle.
+  template <typename U>
+    requires is_protocol_conformant_v<T, std::remove_cvref_t<U>> &&
+                 (!is_protocol_view_v<std::remove_cvref_t<U>>) &&
+                 (!std::is_const_v<U>)
+  protocol_view(const U&&) = delete;
+
   // Views the object a `protocol<T>` owns, sharing its vtable.
   //
   // Precondition: `p` is not valueless.


### PR DESCRIPTION
DRAFT.md's synopsis declares a deleted rvalue constructor on both `protocol_view` specialisations, but the implementation had it only on `protocol_view<const T>`. `protocol_view<T>` relied on its `U&` constructor failing to bind, so viewing a temporary produced a different diagnostic for the mutable and const views.

Adds the deleted overload with the same constraints as the `U&` constructor, so both views report use of a deleted function pointing at the "would dangle" comment.

Closes #285