### PR TITLE
Prefer Bazel for building and testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,35 @@ This document explains how to set up, build, and understand the internals of the
 
 ### Prerequisites
 
-Before building, ensure you have [CMake](https://cmake.org/download/) 3.25 or
-later, a GCC with C++26 reflection (P2996) support, and
+Before building, ensure you have
+[Bazelisk](https://github.com/bazelbuild/bazelisk) (which fetches a current
+Bazel release on first use), a GCC with C++26 reflection (P2996) support, and
 [uv](https://docs.astral.sh/uv/getting-started/installation/) installed. The
 reflection compiler is either the GCC trunk snapshot from
 [jwakely.github.io/pkg-gcc-latest](https://jwakely.github.io/pkg-gcc-latest/)
 or Ubuntu 26.04's `gcc-16` package. The project relies on `uv` to manage
-Python dependencies and execute build scripts.
+Python dependencies and execute build scripts. The CMake build, used for
+sanitizers, coverage and clang-tidy, additionally needs
+[CMake](https://cmake.org/download/) 3.25 or later.
 
 ### Building and Testing
 
-The project supports both CMake and Bazel build systems.
+The project supports both Bazel and CMake build systems. Prefer Bazel for
+day-to-day building and testing: on a two-core codespace a full Bazel build
+took 140 s against 223 s for CMake, and rebuilding after a one-character edit
+to `protocol.hh` took 45 s against 81 s.
 
-1. **CMake**: To build the project and run tests with CMake, execute:
+1. **Bazel** (preferred): To build the project and run tests, execute:
+
+```bash
+./scripts/bazel.sh
+```
+
+Pass `build` to compile without running tests, or `--clean` to expunge the
+Bazel cache first.
+
+2. **CMake**: The CMake build provides the sanitizer, coverage and clang-tidy
+configurations described below. To build and test with it, execute:
 
 ```bash
 ./scripts/cmake.sh
@@ -26,14 +42,8 @@ The project supports both CMake and Bazel build systems.
 
 For more detailed CMake options, run `./scripts/cmake.sh --help`.
 
-2. **Bazel**: To build the project and run tests with Bazel, execute:
-
-```bash
-./scripts/bazel.sh
-```
-
 Both scripts select a reflection-capable compiler and pass it to their
-underlying build system; a bare `cmake`/`bazel` invocation skips that and
+underlying build system; a bare `bazel`/`cmake` invocation skips that and
 fails on stock GCC.
 
 ### Continuous Integration

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,18 +18,21 @@ general defaults for this repository.
 ## Workflow Mandates
 
 - **Tooling:** Always use `uv` for Python dependency management (`uv run ...`).
-- **Build & Test:** Use `scripts/cmake.sh` for all CMake build and test
-  operations, and `scripts/bazel.sh` for Bazel. Both entrypoints discover a
+- **Build & Test:** Prefer `scripts/bazel.sh` for building and testing; it
+  is markedly faster than the CMake build, both from scratch and after
+  editing `protocol.hh`. Use `scripts/cmake.sh` only for what Bazel does not
+  provide: sanitizers, coverage, and clang-tidy. Both entrypoints discover a
   reflection-capable compiler and pass it to the build system; a bare
-  `cmake`/`bazel` invocation uses stock GCC and fails on `-freflection`.
-  The `scripts/cmake.sh` entrypoint supports `--debug`, `--release`,
-  `--asan`, `--ubsan`, `--tsan`, and `--clang-tidy`; `scripts/bazel.sh`
-  supports `build`/`test` and `--clean`.
+  `bazel`/`cmake` invocation uses stock GCC and fails on `-freflection`.
+  The `scripts/bazel.sh` entrypoint supports `build`/`test` and `--clean`;
+  `scripts/cmake.sh` supports `--debug`, `--release`, `--asan`, `--ubsan`,
+  `--tsan`, `--coverage`, and `--clang-tidy`.
 - **Compiler:** The implementation requires GCC with C++26 reflection (the GCC
   trunk snapshot in `/opt/gcc-latest`, or `gcc-16`); CI, including the
   sanitizer jobs, runs on GCC trunk.
-- **Verification:** All changes must be verified using the `scripts/cmake.sh`
-  script to build and test the implementation.
+- **Verification:** All changes must be verified by building and testing the
+  implementation, with `scripts/bazel.sh` by default. Changes to CMake files
+  or to `scripts/cmake.py` must also be verified with `scripts/cmake.sh`.
 - **Sanitizer Verification:** When modifying memory-sensitive or concurrent
   code, verify changes locally using at least one sanitizer (e.g.,
   `./scripts/cmake.sh --asan` or `--tsan`). Note that ASAN and TSAN are
@@ -49,4 +52,5 @@ general defaults for this repository.
 
 - Implementation: `protocol.hh`
 - Proposal Draft: `DRAFT.md`
-- Build Entrypoints: `scripts/cmake.sh` (CMake), `scripts/bazel.sh` (Bazel)
+- Build Entrypoints: `scripts/bazel.sh` (Bazel, preferred), `scripts/cmake.sh`
+  (CMake: sanitizers, coverage, clang-tidy)

--- a/scripts/agentic-sandbox.py
+++ b/scripts/agentic-sandbox.py
@@ -161,7 +161,7 @@ def main() -> None:
 
     if args.agent is None:
         print("To build and test (GCC trunk with C++26 reflection):")
-        print("  ./scripts/cmake.sh --release")
+        print("  ./scripts/bazel.sh")
         container_cmd = None
     else:
         cli = AGENT_CLIS[args.agent]


### PR DESCRIPTION
Bazel builds this project faster than CMake, both from scratch and after
editing `protocol.hh`. Measured on a two-core codespace from fresh
directories, with Bazel given its own output root and repository cache so
nothing was reused:

| Scenario | CMake | Bazel |
|---|---|---|
| Full build | 223 s | 140 s |
| One-character comment change in `protocol.hh` | 81 s | 45 s |

Both systems rebuild the same three test translation units and relink after
the comment change.

Reword the agent instructions (`GEMINI.md`, which `CLAUDE.md` and
`Agents.md` link to), the developer guide and the sandbox hint to prefer
`scripts/bazel.sh`. CMake remains the path for sanitizers, coverage and
clang-tidy, and is still required when CMake files or `scripts/cmake.py`
change.
