### PR TITLE
Use Bazel for the sanitizer CI jobs

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,3 @@
 build
 _deps
+.claude

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,3 +19,22 @@ build --cxxopt=-Wno-self-move
 
 # Show test output on failure
 test --test_output=errors
+
+# Sanitizer builds, matching the flags cmake/sanitizers.cmake applies. Select
+# one with `--config=asan`, `--config=ubsan`, or `--config=tsan`
+# (`scripts/bazel.sh --asan/--ubsan/--tsan`). `--copt` rather than `--cxxopt`
+# so external dependencies (googletest) are instrumented too, and `dbg` so
+# sanitizer reports carry symbolised stack traces. ASAN and TSAN cannot be
+# combined; ASAN and UBSAN can.
+build:asan --compilation_mode=dbg
+build:asan --copt=-fsanitize=address
+build:asan --copt=-fno-omit-frame-pointer
+build:asan --linkopt=-fsanitize=address
+
+build:ubsan --compilation_mode=dbg
+build:ubsan --copt=-fsanitize=undefined
+build:ubsan --linkopt=-fsanitize=undefined
+
+build:tsan --compilation_mode=dbg
+build:tsan --copt=-fsanitize=thread
+build:tsan --linkopt=-fsanitize=thread

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -66,12 +66,15 @@ jobs:
 
   build:
     needs: detect-changes
-    # Run unless change detection positively reported that nothing relevant
-    # changed. `!cancelled()` lets this job run when `detect-changes` was
-    # skipped (push and schedule events), and an empty output (because
-    # `detect-changes` failed) falls through to running the build rather than
-    # silently passing the required check.
-    if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
+    # `!cancelled()` lets this job run when `detect-changes` was skipped (push
+    # and schedule events). When change detection positively reported that
+    # nothing relevant changed, every step below is skipped rather than the
+    # job itself: a matrix job skipped at job level never expands its matrix
+    # and reports a single check under the unexpanded name
+    # "${{ matrix.settings.name }}". An empty output (because `detect-changes`
+    # failed) falls through to running the build rather than silently passing
+    # the required check.
+    if: ${{ !cancelled() }}
     name: ${{ matrix.settings.name }}
     runs-on: ${{ matrix.settings.os }}
     strategy:
@@ -109,8 +112,9 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v5
+        if: needs.detect-changes.outputs.relevant != 'false'
       - name: Install GCC trunk
-        if: matrix.settings.compiler.type == 'GCC_TRUNK'
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC_TRUNK'
         # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
         # scripts/bazel.py finds /opt/gcc-latest itself, so no PATH changes are needed.
         # The unversioned URL tracks upstream weekly. If a snapshot regression breaks
@@ -121,7 +125,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ./gcc-latest.deb
       - name: Install GCC 16
-        if: matrix.settings.compiler.type == 'GCC16'
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC16'
         # Set CXX/CC explicitly so scripts/bazel.py does not pick a stray
         # /opt/gcc-latest on the runner.
         run: |
@@ -130,22 +134,24 @@ jobs:
           echo "CXX=$(which ${{ matrix.settings.compiler.cxx }})" >> "$GITHUB_ENV"
           echo "CC=$(which ${{ matrix.settings.compiler.cc }})" >> "$GITHUB_ENV"
       - name: Install uv
+        if: needs.detect-changes.outputs.relevant != 'false'
         uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python
+        if: needs.detect-changes.outputs.relevant != 'false'
         run: uv sync
       - name: Set up Bazel
+        if: needs.detect-changes.outputs.relevant != 'false'
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
       - name: Run Bazel
+        if: needs.detect-changes.outputs.relevant != 'false'
         run: ./scripts/bazel.sh
 
-  # The per-compiler checks cannot be required status checks: a matrix job
-  # skipped by its job-level `if:` reports a single check under the
-  # unexpanded name "${{ matrix.settings.name }}", so on pull requests where
-  # `detect-changes` skips the build the expanded names never report. This
-  # non-matrix job always reports under a fixed name; require it instead.
+  # This non-matrix job reports under a fixed name whatever the matrix above
+  # did, so the ruleset can require one check per workflow instead of every
+  # per-compiler entry.
   summary:
     name: bazel
     needs: [detect-changes, build]

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -58,12 +58,15 @@ jobs:
 
   build:
     needs: detect-changes
-    # Run unless change detection positively reported that nothing relevant
-    # changed. `!cancelled()` lets this job run when `detect-changes` was
-    # skipped (push and schedule events), and an empty output (because
-    # `detect-changes` failed) falls through to running the build rather than
-    # silently passing the required check.
-    if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
+    # `!cancelled()` lets this job run when `detect-changes` was skipped (push
+    # and schedule events). When change detection positively reported that
+    # nothing relevant changed, every step below is skipped rather than the
+    # job itself: a matrix job skipped at job level never expands its matrix
+    # and reports a single check under the unexpanded name
+    # "${{ matrix.settings.name }} ${{ matrix.configuration }}". An empty
+    # output (because `detect-changes` failed) falls through to running the
+    # build rather than silently passing the required check.
+    if: ${{ !cancelled() }}
     name: ${{ matrix.settings.name }} ${{ matrix.configuration }}
     runs-on: ${{ matrix.settings.os }}
     strategy:
@@ -102,9 +105,11 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v5
+        if: needs.detect-changes.outputs.relevant != 'false'
       - uses: lukka/get-cmake@v4.4.2
+        if: needs.detect-changes.outputs.relevant != 'false'
       - name: Install GCC trunk
-        if: matrix.settings.compiler.type == 'GCC_TRUNK'
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC_TRUNK'
         # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
         # scripts/cmake.py finds /opt/gcc-latest itself, so no PATH changes are needed.
         # The unversioned URL tracks upstream weekly. If a snapshot regression breaks
@@ -115,7 +120,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ./gcc-latest.deb
       - name: Install GCC 16
-        if: matrix.settings.compiler.type == 'GCC16'
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC16'
         # Set CXX/CC explicitly so scripts/cmake.py does not pick a stray
         # /opt/gcc-latest on the runner.
         run: |
@@ -124,18 +129,18 @@ jobs:
           echo "CXX=${{ matrix.settings.compiler.cxx }}" >> "$GITHUB_ENV"
           echo "CC=${{ matrix.settings.compiler.cc }}" >> "$GITHUB_ENV"
       - name: Install uv
+        if: needs.detect-changes.outputs.relevant != 'false'
         uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python
+        if: needs.detect-changes.outputs.relevant != 'false'
         run: uv sync
       - name: Run CMake
+        if: needs.detect-changes.outputs.relevant != 'false'
         run: ./scripts/cmake.sh --${{ matrix.configuration == 'Debug' && 'debug' || 'release' }}
 
-  # The per-configuration checks cannot be required status checks: a matrix
-  # job skipped by its job-level `if:` reports a single check under the
-  # unexpanded name "${{ matrix.settings.name }} ${{ matrix.configuration }}",
-  # so on pull requests where `detect-changes` skips the build the expanded
-  # names never report. This non-matrix job always reports under a fixed
-  # name; require it instead.
+  # This non-matrix job reports under a fixed name whatever the matrix above
+  # did, so the ruleset can require one check per workflow instead of every
+  # per-configuration entry.
   summary:
     name: cmake
     needs: [detect-changes, build]

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -76,12 +76,15 @@ jobs:
 
   sanitized-tests:
     needs: detect-changes
-    # Run unless change detection positively reported that nothing relevant
-    # changed. `!cancelled()` lets this job run when `detect-changes` was
-    # skipped (push and schedule events), and an empty output (because
-    # `detect-changes` failed) falls through to running the build rather than
-    # silently passing the required check.
-    if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
+    # `!cancelled()` lets this job run when `detect-changes` was skipped (push
+    # and schedule events). When change detection positively reported that
+    # nothing relevant changed, every step below is skipped rather than the
+    # job itself: a matrix job skipped at job level never expands its matrix
+    # and reports a single check under the unexpanded name
+    # "${{ matrix.build_system }} ${{ matrix.sanitizer }}". An empty output
+    # (because `detect-changes` failed) falls through to running the build
+    # rather than silently passing the required check.
+    if: ${{ !cancelled() }}
     name: ${{ matrix.build_system }} ${{ matrix.sanitizer }}
     runs-on: ubuntu-26.04
     strategy:
@@ -95,9 +98,11 @@ jobs:
         sanitizer: ["asan", "tsan"]
     steps:
       - uses: actions/checkout@v5
+        if: needs.detect-changes.outputs.relevant != 'false'
       - uses: lukka/get-cmake@v4.4.2
-        if: matrix.build_system == 'cmake'
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.build_system == 'cmake'
       - name: Install GCC trunk
+        if: needs.detect-changes.outputs.relevant != 'false'
         # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
         # scripts/cmake.py and scripts/bazel.py find /opt/gcc-latest themselves,
         # so no PATH changes are needed.
@@ -107,11 +112,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ./gcc-latest.deb
       - name: Install uv
+        if: needs.detect-changes.outputs.relevant != 'false'
         uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python
+        if: needs.detect-changes.outputs.relevant != 'false'
         run: uv sync
       - name: Set up Bazel
-        if: matrix.build_system == 'bazel'
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.build_system == 'bazel'
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
@@ -119,7 +126,7 @@ jobs:
           # race to save under the same key and one of them would lose.
           disk-cache: ${{ github.workflow }}-${{ matrix.sanitizer }}
       - name: Run CMake
-        if: matrix.build_system == 'cmake'
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.build_system == 'cmake'
         run: |
           UBSAN_FLAG=""
           if [ "${{ matrix.sanitizer }}" = "asan" ]; then
@@ -127,7 +134,7 @@ jobs:
           fi
           ./scripts/cmake.sh --debug --${{ matrix.sanitizer }} ${UBSAN_FLAG}
       - name: Run Bazel
-        if: matrix.build_system == 'bazel'
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.build_system == 'bazel'
         run: |
           UBSAN_FLAG=""
           if [ "${{ matrix.sanitizer }}" = "asan" ]; then
@@ -135,11 +142,9 @@ jobs:
           fi
           ./scripts/bazel.sh --${{ matrix.sanitizer }} ${UBSAN_FLAG}
 
-  # The per-sanitizer checks cannot be required status checks: a matrix
-  # job skipped by its job-level `if:` reports a single check under the
-  # unexpanded name "${{ matrix.build_system }} ${{ matrix.sanitizer }}", so on pull requests where
-  # `detect-changes` skips the tests the expanded names never report. This
-  # non-matrix job always reports under a fixed name; require it instead.
+  # This non-matrix job reports under a fixed name whatever the matrix above
+  # did, so the ruleset can require one check per workflow instead of every
+  # per-sanitizer entry.
   summary:
     name: sanitizers
     needs: [detect-changes, sanitized-tests]

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -10,11 +10,6 @@ on:
       - "**/*.cc"
       - "**/*.h"
       - "**/*.hh"
-      - "**/CMakeLists.txt"
-      - "CMakePresets.json"
-      - "**/*.cmake"
-      - "scripts/cmake.py"
-      - "scripts/cmake.sh"
       - "**/*.bazel"
       - "BUILD.bazel"
       - "MODULE.bazel"
@@ -58,11 +53,6 @@ jobs:
               - "**/*.cc"
               - "**/*.h"
               - "**/*.hh"
-              - "**/CMakeLists.txt"
-              - "CMakePresets.json"
-              - "**/*.cmake"
-              - "scripts/cmake.py"
-              - "scripts/cmake.sh"
               - "**/*.bazel"
               - "BUILD.bazel"
               - "MODULE.bazel"
@@ -81,32 +71,25 @@ jobs:
     # nothing relevant changed, every step below is skipped rather than the
     # job itself: a matrix job skipped at job level never expands its matrix
     # and reports a single check under the unexpanded name
-    # "${{ matrix.build_system }} ${{ matrix.sanitizer }}". An empty output
-    # (because `detect-changes` failed) falls through to running the build
-    # rather than silently passing the required check.
+    # "${{ matrix.sanitizer }}". An empty output (because `detect-changes`
+    # failed) falls through to running the build rather than silently passing
+    # the required check.
     if: ${{ !cancelled() }}
-    name: ${{ matrix.build_system }} ${{ matrix.sanitizer }}
+    name: ${{ matrix.sanitizer }}
     runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
-        # The same sanitizers run under both build systems for now (issue
-        # #292): Bazel builds are faster, and the CMake jobs stay until the
-        # Bazel ones have proven themselves.
-        build_system: ["cmake", "bazel"]
         # GCC has no MemorySanitizer, so there is no msan job.
         sanitizer: ["asan", "tsan"]
     steps:
       - uses: actions/checkout@v5
         if: needs.detect-changes.outputs.relevant != 'false'
-      - uses: lukka/get-cmake@v4.4.2
-        if: needs.detect-changes.outputs.relevant != 'false' && matrix.build_system == 'cmake'
       - name: Install GCC trunk
         if: needs.detect-changes.outputs.relevant != 'false'
         # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
-        # scripts/cmake.py and scripts/bazel.py find /opt/gcc-latest themselves,
-        # so no PATH changes are needed.
-        # Keep in sync with the same step in cmake.yml and bazel.yml.
+        # scripts/bazel.py finds /opt/gcc-latest itself, so no PATH changes are needed.
+        # Keep in sync with the same step in bazel.yml.
         run: |
           wget --quiet https://kayari.org/gcc-latest/gcc-latest.deb
           sudo apt-get update
@@ -118,23 +101,15 @@ jobs:
         if: needs.detect-changes.outputs.relevant != 'false'
         run: uv sync
       - name: Set up Bazel
-        if: needs.detect-changes.outputs.relevant != 'false' && matrix.build_system == 'bazel'
+        if: needs.detect-changes.outputs.relevant != 'false'
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          # One disk cache per sanitizer: the two Bazel jobs would otherwise
-          # race to save under the same key and one of them would lose.
+          # One disk cache per sanitizer: the two jobs would otherwise race
+          # to save under the same key and one of them would lose.
           disk-cache: ${{ github.workflow }}-${{ matrix.sanitizer }}
-      - name: Run CMake
-        if: needs.detect-changes.outputs.relevant != 'false' && matrix.build_system == 'cmake'
-        run: |
-          UBSAN_FLAG=""
-          if [ "${{ matrix.sanitizer }}" = "asan" ]; then
-            UBSAN_FLAG="--ubsan"
-          fi
-          ./scripts/cmake.sh --debug --${{ matrix.sanitizer }} ${UBSAN_FLAG}
       - name: Run Bazel
-        if: needs.detect-changes.outputs.relevant != 'false' && matrix.build_system == 'bazel'
+        if: needs.detect-changes.outputs.relevant != 'false'
         run: |
           UBSAN_FLAG=""
           if [ "${{ matrix.sanitizer }}" = "asan" ]; then

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
     paths:
-      - ".github/workflows/sanitizers.yml"
+      - ".github/workflows/sanitizers.yml" # This file
       - "**/*.cc"
       - "**/*.h"
       - "**/*.hh"
@@ -15,7 +15,16 @@ on:
       - "**/*.cmake"
       - "scripts/cmake.py"
       - "scripts/cmake.sh"
+      - "**/*.bazel"
+      - "BUILD.bazel"
+      - "MODULE.bazel"
+      - "MODULE.bazel.lock"
+      - ".bazelrc"
+      - ".bazelignore"
+      - "scripts/bazel.py"
+      - "scripts/bazel.sh"
       - "scripts/compiler_discovery.py"
+      - "tutorials/BUILD.bazel"
   # No `paths:` filter here. The `sanitizers` summary job is a required
   # status check for merging to main, and a workflow that is filtered out by
   # `paths:` never reports a check, which leaves unrelated pull requests
@@ -45,7 +54,7 @@ jobs:
           # Keep in sync with the `push.paths` list above.
           filters: |
             relevant:
-              - ".github/workflows/sanitizers.yml"
+              - ".github/workflows/sanitizers.yml" # This file
               - "**/*.cc"
               - "**/*.h"
               - "**/*.hh"
@@ -54,7 +63,16 @@ jobs:
               - "**/*.cmake"
               - "scripts/cmake.py"
               - "scripts/cmake.sh"
+              - "**/*.bazel"
+              - "BUILD.bazel"
+              - "MODULE.bazel"
+              - "MODULE.bazel.lock"
+              - ".bazelrc"
+              - ".bazelignore"
+              - "scripts/bazel.py"
+              - "scripts/bazel.sh"
               - "scripts/compiler_discovery.py"
+              - "tutorials/BUILD.bazel"
 
   sanitized-tests:
     needs: detect-changes
@@ -64,20 +82,26 @@ jobs:
     # `detect-changes` failed) falls through to running the build rather than
     # silently passing the required check.
     if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
-    name: ${{ matrix.sanitizer }}
+    name: ${{ matrix.build_system }} ${{ matrix.sanitizer }}
     runs-on: ubuntu-26.04
     strategy:
       fail-fast: false
       matrix:
+        # The same sanitizers run under both build systems for now (issue
+        # #292): Bazel builds are faster, and the CMake jobs stay until the
+        # Bazel ones have proven themselves.
+        build_system: ["cmake", "bazel"]
         # GCC has no MemorySanitizer, so there is no msan job.
         sanitizer: ["asan", "tsan"]
     steps:
       - uses: actions/checkout@v5
       - uses: lukka/get-cmake@v4.4.2
+        if: matrix.build_system == 'cmake'
       - name: Install GCC trunk
         # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
-        # scripts/cmake.py finds /opt/gcc-latest itself, so no PATH changes are needed.
-        # Keep in sync with the same step in cmake.yml.
+        # scripts/cmake.py and scripts/bazel.py find /opt/gcc-latest themselves,
+        # so no PATH changes are needed.
+        # Keep in sync with the same step in cmake.yml and bazel.yml.
         run: |
           wget --quiet https://kayari.org/gcc-latest/gcc-latest.deb
           sudo apt-get update
@@ -86,17 +110,34 @@ jobs:
         uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python
         run: uv sync
+      - name: Set up Bazel
+        if: matrix.build_system == 'bazel'
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          # One disk cache per sanitizer: the two Bazel jobs would otherwise
+          # race to save under the same key and one of them would lose.
+          disk-cache: ${{ github.workflow }}-${{ matrix.sanitizer }}
       - name: Run CMake
+        if: matrix.build_system == 'cmake'
         run: |
           UBSAN_FLAG=""
           if [ "${{ matrix.sanitizer }}" = "asan" ]; then
             UBSAN_FLAG="--ubsan"
           fi
           ./scripts/cmake.sh --debug --${{ matrix.sanitizer }} ${UBSAN_FLAG}
+      - name: Run Bazel
+        if: matrix.build_system == 'bazel'
+        run: |
+          UBSAN_FLAG=""
+          if [ "${{ matrix.sanitizer }}" = "asan" ]; then
+            UBSAN_FLAG="--ubsan"
+          fi
+          ./scripts/bazel.sh --${{ matrix.sanitizer }} ${UBSAN_FLAG}
 
-  # The `asan` and `tsan` checks cannot be required status checks: a matrix
+  # The per-sanitizer checks cannot be required status checks: a matrix
   # job skipped by its job-level `if:` reports a single check under the
-  # unexpanded name "${{ matrix.sanitizer }}", so on pull requests where
+  # unexpanded name "${{ matrix.build_system }} ${{ matrix.sanitizer }}", so on pull requests where
   # `detect-changes` skips the tests the expanded names never report. This
   # non-matrix job always reports under a fixed name; require it instead.
   summary:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,8 @@ are required for merging to `main`: `GCC trunk Release`, `GCC trunk Debug`,
 
 On pull requests that touch no C++, CMake, Bazel, or build-script sources,
 a change-detection job makes the build and sanitizer jobs skip their steps,
-so they pass without building. The sanitizer jobs run under both CMake and Bazel
-(`--asan --ubsan` and `--tsan`, through `scripts/cmake.sh --debug` and
-`scripts/bazel.sh`).
+so they pass without building. The sanitizer jobs build with Bazel
+(`./scripts/bazel.sh --asan --ubsan` and `./scripts/bazel.sh --tsan`).
 
 ### Static Analysis
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ reflection compiler is either the GCC trunk snapshot from
 [jwakely.github.io/pkg-gcc-latest](https://jwakely.github.io/pkg-gcc-latest/)
 or Ubuntu 26.04's `gcc-16` package. The project relies on `uv` to manage
 Python dependencies and execute build scripts. The CMake build, used for
-sanitizers, coverage and clang-tidy, additionally needs
+coverage and clang-tidy, additionally needs
 [CMake](https://cmake.org/download/) 3.25 or later.
 
 ### Building and Testing
@@ -30,11 +30,13 @@ to `protocol.hh` took 45 s against 81 s.
 ./scripts/bazel.sh
 ```
 
-Pass `build` to compile without running tests, or `--clean` to expunge the
-Bazel cache first.
+Pass `build` to compile without running tests, `--asan`, `--ubsan`, or
+`--tsan` for a sanitized build (`--asan` and `--tsan` cannot be combined), or
+`--clean` to expunge the Bazel cache first.
 
-2. **CMake**: The CMake build provides the sanitizer, coverage and clang-tidy
-configurations described below. To build and test with it, execute:
+2. **CMake**: The CMake build provides the coverage and clang-tidy
+configurations described below, and the same sanitizer flags as Bazel. To
+build and test with it, execute:
 
 ```bash
 ./scripts/cmake.sh
@@ -52,9 +54,11 @@ Pull requests run the workflows in `.github/workflows`. The following checks
 are required for merging to `main`: `GCC trunk Release`, `GCC trunk Debug`,
 `GCC-16 Release`, `GCC-16 Debug`, `asan`, `tsan`, `uv-lock`, `pre-commit`.
 
-On pull requests that touch no C++, CMake, or build-script sources, the build
-and sanitizer jobs are skipped by a change-detection job, which counts as
-passing.
+On pull requests that touch no C++, CMake, Bazel, or build-script sources,
+the build and sanitizer jobs are skipped by a change-detection job, which
+counts as passing. The sanitizer jobs run under both CMake and Bazel
+(`--asan --ubsan` and `--tsan`, through `scripts/cmake.sh --debug` and
+`scripts/bazel.sh`).
 
 ### Static Analysis
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,8 @@ are required for merging to `main`: `GCC trunk Release`, `GCC trunk Debug`,
 `GCC-16 Release`, `GCC-16 Debug`, `asan`, `tsan`, `uv-lock`, `pre-commit`.
 
 On pull requests that touch no C++, CMake, Bazel, or build-script sources,
-the build and sanitizer jobs are skipped by a change-detection job, which
-counts as passing. The sanitizer jobs run under both CMake and Bazel
+a change-detection job makes the build and sanitizer jobs skip their steps,
+so they pass without building. The sanitizer jobs run under both CMake and Bazel
 (`--asan --ubsan` and `--tsan`, through `scripts/cmake.sh --debug` and
 `scripts/bazel.sh`).
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -37,8 +37,8 @@ general defaults for this repository.
 - **Sanitizer Verification:** When modifying memory-sensitive or concurrent
   code, verify changes locally using at least one sanitizer (e.g.,
   `./scripts/bazel.sh --asan` or `--tsan`; `scripts/cmake.sh` takes the same
-  flags). CI runs the sanitizers under both build systems. Note that ASAN and
-  TSAN are mutually exclusive.
+  flags). CI runs the sanitizers through Bazel. Note that ASAN and TSAN are
+  mutually exclusive.
 - **Post-Change Checks:** Tests and pre-commit checks MUST be run after any
   modifications to the codebase.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,12 +21,13 @@ general defaults for this repository.
 - **Build & Test:** Prefer `scripts/bazel.sh` for building and testing; it
   is markedly faster than the CMake build, both from scratch and after
   editing `protocol.hh`. Use `scripts/cmake.sh` only for what Bazel does not
-  provide: sanitizers, coverage, and clang-tidy. Both entrypoints discover a
+  provide: coverage and clang-tidy. Both entrypoints discover a
   reflection-capable compiler and pass it to the build system; a bare
   `bazel`/`cmake` invocation uses stock GCC and fails on `-freflection`.
-  The `scripts/bazel.sh` entrypoint supports `build`/`test` and `--clean`;
-  `scripts/cmake.sh` supports `--debug`, `--release`, `--asan`, `--ubsan`,
-  `--tsan`, `--coverage`, and `--clang-tidy`.
+  The `scripts/bazel.sh` entrypoint supports `build`/`test`, `--clean`,
+  `--asan`, `--ubsan`, and `--tsan`; `scripts/cmake.sh` supports `--debug`,
+  `--release`, `--asan`, `--ubsan`, `--tsan`, `--coverage`, and
+  `--clang-tidy`.
 - **Compiler:** The implementation requires GCC with C++26 reflection (the GCC
   trunk snapshot in `/opt/gcc-latest`, or `gcc-16`); CI, including the
   sanitizer jobs, runs on GCC trunk.
@@ -35,8 +36,9 @@ general defaults for this repository.
   or to `scripts/cmake.py` must also be verified with `scripts/cmake.sh`.
 - **Sanitizer Verification:** When modifying memory-sensitive or concurrent
   code, verify changes locally using at least one sanitizer (e.g.,
-  `./scripts/cmake.sh --asan` or `--tsan`). Note that ASAN and TSAN are
-  mutually exclusive.
+  `./scripts/bazel.sh --asan` or `--tsan`; `scripts/cmake.sh` takes the same
+  flags). CI runs the sanitizers under both build systems. Note that ASAN and
+  TSAN are mutually exclusive.
 - **Post-Change Checks:** Tests and pre-commit checks MUST be run after any
   modifications to the codebase.
 
@@ -53,4 +55,4 @@ general defaults for this repository.
 - Implementation: `protocol.hh`
 - Proposal Draft: `DRAFT.md`
 - Build Entrypoints: `scripts/bazel.sh` (Bazel, preferred), `scripts/cmake.sh`
-  (CMake: sanitizers, coverage, clang-tidy)
+  (CMake: coverage, clang-tidy)

--- a/scripts/bazel.py
+++ b/scripts/bazel.py
@@ -31,10 +31,22 @@ def main() -> None:
         help="Clean Bazel build artifacts and expunge cache",
     )
     argument_parser.add_argument(
+        "--asan", action="store_true", help="Enable Address Sanitizer"
+    )
+    argument_parser.add_argument(
+        "--ubsan", action="store_true", help="Enable Undefined Behaviour Sanitizer"
+    )
+    argument_parser.add_argument(
+        "--tsan", action="store_true", help="Enable Thread Sanitizer"
+    )
+    argument_parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable verbose logging"
     )
 
     parsed_arguments = argument_parser.parse_args()
+
+    if parsed_arguments.asan and parsed_arguments.tsan:
+        argument_parser.error("--asan and --tsan cannot be combined")
 
     mode_map = {
         "b": "build",
@@ -58,6 +70,13 @@ def main() -> None:
         subprocess.check_call(clean_command, cwd=SOURCE_ROOT, env=bazel_environment)
 
     bazel_command = ["bazel", target_mode]
+
+    # Each sanitizer is a named config in .bazelrc; `bazel test --config=...`
+    # applies the build config to the test build as well.
+    for sanitizer_name in ("asan", "ubsan", "tsan"):
+        if getattr(parsed_arguments, sanitizer_name):
+            bazel_command.append(f"--config={sanitizer_name}")
+
     bazel_command.append("--action_env=PATH")
     bazel_command.append("--repo_env=PATH")
 


### PR DESCRIPTION
Closes #292.

The sanitizer CI jobs now build and test with Bazel instead of CMake. The branch first ran both side by side to compare them; the findings are below.

- `.bazelrc` gains `asan`, `ubsan`, and `tsan` configs with the same flags `cmake/sanitizers.cmake` applies. They use `--copt` so googletest is instrumented too, and `--compilation_mode=dbg` so reports carry symbolised stack traces.
- `scripts/bazel.sh` takes `--asan`, `--ubsan`, and `--tsan`, mirroring `scripts/cmake.sh`; `--asan` with `--tsan` is rejected. The CMake flags stay for local use.
- `sanitizers.yml` sets up Bazel with a per-sanitizer disk cache and runs `./scripts/bazel.sh --asan --ubsan` and `./scripts/bazel.sh --tsan`. Its paths filters track the Bazel inputs instead of the CMake ones.
- The change-detection skip moves from job level to step level in `cmake.yml`, `bazel.yml`, and `sanitizers.yml`, so skipped matrix jobs no longer report under the unexpanded name `${{ matrix.settings.name }} ${{ matrix.configuration }}`.
- `.bazelignore` also ignores `.claude`, where Claude Code keeps agent worktrees whose `build/` directories otherwise make `bazel test //...` fail to load.
- Docs updated.

The `asan`, `tsan`, and `sanitizers` check names are unchanged, so the required-check ruleset needs no change.

### Findings from four runs with both build systems

Build-and-test step, seconds:

| Run | cmake asan | cmake tsan | bazel asan | bazel tsan |
|---|---|---|---|---|
| Cold cache | 85 | 78 | 91 | 92 |
| Warm rerun, no change | 88 | 78 | 21 | 16 |
| Push after main changed `protocol.hh` | 88 | 78 | 61 | 64 |
| After rebase | 89 | 68 | 77 | 65 |

- Bazel is never slower than CMake and drops to about 20 s when nothing changed. Whole-job times are equal within noise because the "Install GCC trunk" step (81 to 149 s, mostly the package's `mkheaders` postinst) dominates both; #297 tracks caching it.
- The setup-bazel disk cache saves only on an exact key miss, so it froze at the first run's contents and later runs stayed partially warm; #298 tracks saving it per run.
