### PR TITLE
Cache the installed GCC trunk tree between CI runs

### DIFF
--- a/.github/actions/install-gcc-trunk/action.yml
+++ b/.github/actions/install-gcc-trunk/action.yml
@@ -1,0 +1,72 @@
+name: Install GCC trunk
+description: >-
+  Install the prebuilt GCC trunk snapshot from
+  https://jwakely.github.io/pkg-gcc-latest/ into /opt/gcc-latest, restoring
+  the installed tree from the Actions cache while the snapshot is unchanged.
+  scripts/cmake.py and scripts/bazel.py find /opt/gcc-latest themselves, so
+  callers need no PATH changes.
+
+inputs:
+  package-url:
+    description: >-
+      URL of the snapshot .deb. The default tracks upstream weekly; if a
+      snapshot regression breaks a job, pin the versioned file linked from
+      https://jwakely.github.io/pkg-gcc-latest/, e.g.
+      https://kayari.org/gcc-latest/gcc-latest_17.0.0-20260816git8df013222dff.deb
+    required: false
+    default: https://kayari.org/gcc-latest/gcc-latest.deb
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve the snapshot
+      id: snapshot
+      shell: bash
+      # The unversioned URL redirects to a versioned file name, and that name
+      # plus the file's Last-Modified date keys the cache. A HEAD request that
+      # follows the redirect finds both without downloading anything. If the
+      # server ever stops providing either, the key would be constant and the
+      # cache would go stale, so caching is skipped rather than keyed blindly.
+      run: |
+        headers=$(curl --silent --show-error --fail --head --location \
+          "${{ inputs.package-url }}" | tr -d '\r')
+        final_url=$(printf '%s\n' "$headers" | sed -n 's/^[Ll]ocation: //p' | tail -1)
+        final_url=${final_url:-${{ inputs.package-url }}}
+        last_modified=$(printf '%s\n' "$headers" | sed -n 's/^[Ll]ast-[Mm]odified: //p' | tail -1)
+        file_name=$(basename "$final_url")
+        if [ "$file_name" = "gcc-latest.deb" ] || [ -z "$last_modified" ]; then
+          echo "::warning::Cannot identify the GCC snapshot ($file_name, '$last_modified'); installing without a cache"
+          echo "cache-key=" >> "$GITHUB_OUTPUT"
+        else
+          date_key=$(printf '%s' "$last_modified" | tr -c 'A-Za-z0-9' '-')
+          echo "cache-key=gcc-trunk-${{ runner.os }}-${{ runner.arch }}-${file_name}-${date_key}" >> "$GITHUB_OUTPUT"
+        fi
+        echo "Snapshot: $file_name ($last_modified)"
+
+    - name: Make /opt/gcc-latest writable for the cache
+      shell: bash
+      # actions/cache extracts as the runner user, and /opt is root-owned.
+      run: |
+        sudo mkdir -p /opt/gcc-latest
+        sudo chown "$(id -u):$(id -g)" /opt/gcc-latest
+
+    - name: Restore the installed tree
+      id: cache
+      if: steps.snapshot.outputs.cache-key != ''
+      uses: actions/cache@v4
+      with:
+        path: /opt/gcc-latest
+        key: ${{ steps.snapshot.outputs.cache-key }}
+
+    - name: Download and install the snapshot
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      # The package's postinst runs GCC's `mkheaders`, which regenerates the
+      # fixed system headers for this machine and is the slow part of the
+      # install. It must run, so the cache holds the installed tree rather
+      # than the .deb.
+      run: |
+        wget --quiet --output-document "$RUNNER_TEMP/gcc-latest.deb" "${{ inputs.package-url }}"
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends "$RUNNER_TEMP/gcc-latest.deb"
+        rm "$RUNNER_TEMP/gcc-latest.deb"

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/bazel.yml" # This file
+      - ".github/actions/install-gcc-trunk/action.yml"
       - "**/*.cc"
       - "**/*.h"
       - "**/*.hh"
@@ -50,6 +51,7 @@ jobs:
           filters: |
             relevant:
               - ".github/workflows/bazel.yml" # This file
+              - ".github/actions/install-gcc-trunk/action.yml"
               - "**/*.cc"
               - "**/*.h"
               - "**/*.hh"
@@ -115,15 +117,8 @@ jobs:
         if: needs.detect-changes.outputs.relevant != 'false'
       - name: Install GCC trunk
         if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC_TRUNK'
-        # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
-        # scripts/bazel.py finds /opt/gcc-latest itself, so no PATH changes are needed.
-        # The unversioned URL tracks upstream weekly. If a snapshot regression breaks
-        # this job, temporarily pin the versioned file linked from that page, e.g.
-        # https://kayari.org/gcc-latest/gcc-latest_17.0.0-20260816git8df013222dff.deb
-        run: |
-          wget --quiet https://kayari.org/gcc-latest/gcc-latest.deb
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ./gcc-latest.deb
+        # Cached between runs; the action documents how to pin a snapshot.
+        uses: ./.github/actions/install-gcc-trunk
       - name: Install GCC 16
         if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC16'
         # Set CXX/CC explicitly so scripts/bazel.py does not pick a stray

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/cmake.yml" # This file
+      - ".github/actions/install-gcc-trunk/action.yml"
       - "**/*.cc"
       - "**/*.h"
       - "**/*.hh"
@@ -46,6 +47,7 @@ jobs:
           filters: |
             relevant:
               - ".github/workflows/cmake.yml" # This file
+              - ".github/actions/install-gcc-trunk/action.yml"
               - "**/*.cc"
               - "**/*.h"
               - "**/*.hh"
@@ -110,15 +112,8 @@ jobs:
         if: needs.detect-changes.outputs.relevant != 'false'
       - name: Install GCC trunk
         if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC_TRUNK'
-        # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
-        # scripts/cmake.py finds /opt/gcc-latest itself, so no PATH changes are needed.
-        # The unversioned URL tracks upstream weekly. If a snapshot regression breaks
-        # this job, temporarily pin the versioned file linked from that page, e.g.
-        # https://kayari.org/gcc-latest/gcc-latest_17.0.0-20260816git8df013222dff.deb
-        run: |
-          wget --quiet https://kayari.org/gcc-latest/gcc-latest.deb
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ./gcc-latest.deb
+        # Cached between runs; the action documents how to pin a snapshot.
+        uses: ./.github/actions/install-gcc-trunk
       - name: Install GCC 16
         if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC16'
         # Set CXX/CC explicitly so scripts/cmake.py does not pick a stray

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/coverage.yml" # This file
+      - ".github/actions/install-gcc-trunk/action.yml"
       - "**/*.cc"
       - "**/*.h"
       - "**/*.hh"
@@ -25,6 +26,7 @@ on:
     paths:
       # Keep in sync with the `push.paths` list above.
       - ".github/workflows/coverage.yml" # This file
+      - ".github/actions/install-gcc-trunk/action.yml"
       - "**/*.cc"
       - "**/*.h"
       - "**/*.hh"
@@ -54,12 +56,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: lukka/get-cmake@v4.4.2
       - name: Install GCC trunk
-        # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
-        # scripts/cmake.py finds /opt/gcc-latest itself, so no PATH changes are needed.
-        run: |
-          wget --quiet https://kayari.org/gcc-latest/gcc-latest.deb
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ./gcc-latest.deb
+        # Cached between runs; the action documents how to pin a snapshot.
+        uses: ./.github/actions/install-gcc-trunk
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python
@@ -86,10 +84,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: lukka/get-cmake@v4.4.2
       - name: Install GCC trunk
-        run: |
-          wget --quiet https://kayari.org/gcc-latest/gcc-latest.deb
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ./gcc-latest.deb
+        uses: ./.github/actions/install-gcc-trunk
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/sanitizers.yml" # This file
+      - ".github/actions/install-gcc-trunk/action.yml"
       - "**/*.cc"
       - "**/*.h"
       - "**/*.hh"
@@ -50,6 +51,7 @@ jobs:
           filters: |
             relevant:
               - ".github/workflows/sanitizers.yml" # This file
+              - ".github/actions/install-gcc-trunk/action.yml"
               - "**/*.cc"
               - "**/*.h"
               - "**/*.hh"
@@ -87,13 +89,8 @@ jobs:
         if: needs.detect-changes.outputs.relevant != 'false'
       - name: Install GCC trunk
         if: needs.detect-changes.outputs.relevant != 'false'
-        # Prebuilt GCC trunk snapshot from https://jwakely.github.io/pkg-gcc-latest/;
-        # scripts/bazel.py finds /opt/gcc-latest itself, so no PATH changes are needed.
-        # Keep in sync with the same step in bazel.yml.
-        run: |
-          wget --quiet https://kayari.org/gcc-latest/gcc-latest.deb
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ./gcc-latest.deb
+        # Cached between runs; the action documents how to pin a snapshot.
+        uses: ./.github/actions/install-gcc-trunk
       - name: Install uv
         if: needs.detect-changes.outputs.relevant != 'false'
         uses: astral-sh/setup-uv@v10.0.1


### PR DESCRIPTION
Closes #297.

Every GCC trunk job spent 81 to 149 s installing the compiler, more than the build it then ran, and most of that was the package's `mkheaders` postinst regenerating fixed headers.

- `.github/actions/install-gcc-trunk` resolves the versioned file the unversioned URL redirects to, restores `/opt/gcc-latest` from the Actions cache under a key made of that file name and its `Last-Modified` date, and falls back to the download and apt install on a miss. If the server ever stops providing either identifier, it installs without caching rather than key blindly.
- The five copies of the install step in `cmake.yml`, `bazel.yml`, `sanitizers.yml`, and `coverage.yml` now use the action, and the action file is in each workflow's paths filter. Pinning a snapshot after an upstream regression is the action's `package-url` input.
