### PR TITLE
Add bazel repository cache for agentic sandbox

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,11 +2,6 @@
 build --cxxopt=-std=c++26
 build --cxxopt=-freflection
 
-# Cache downloaded external dependency archives in their own directory,
-# separate from the default output root (~/.cache/bazel), which also holds
-# build artifacts we don't want to persist across sandbox runs.
-common --repository_cache=~/.cache/bazel-repo
-
 # Treat external repositories' headers (e.g. googletest) as system headers,
 # matching CMake's SYSTEM FetchContent_Declare, so -Werror below only holds
 # our own code to account and not warnings from vendored dependencies.

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,11 @@
 build --cxxopt=-std=c++26
 build --cxxopt=-freflection
 
+# Cache downloaded external dependency archives in their own directory,
+# separate from the default output root (~/.cache/bazel), which also holds
+# build artifacts we don't want to persist across sandbox runs.
+common --repository_cache=~/.cache/bazel-repo
+
 # Treat external repositories' headers (e.g. googletest) as system headers,
 # matching CMake's SYSTEM FetchContent_Declare, so -Werror below only holds
 # our own code to account and not warnings from vendored dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,12 +230,14 @@ plain shell in the container.
 |------|-------------|
 | `--rebuild-docker` | Rebuild the Docker image before starting. |
 | `--update` | Update the agent CLI to the latest version before running. |
-| `--cache-volumes`, `--no-cache-volumes` | Mount the persistent `uv` cache volume (default: on). |
+| `--cache-volumes`, `--no-cache-volumes` | Mount the persistent cache volumes (default: on). |
 | `-v`, `--verbose` | Enable verbose logging. |
 
-The `uv` cache persists across sandbox runs in a Docker named volume,
-`cc-protocol-uv-cache`. The cache grows without bound since `uv` never prunes
-it; to reset it, run `docker volume rm cc-protocol-uv-cache`.
+The `uv` package cache, Bazel's downloaded dependency archives, and pre-commit's
+environment cache persist across sandbox runs in Docker named volumes,
+`cc-protocol-uv-cache`, `cc-protocol-bazel-cache`, and
+`cc-protocol-pre-commit-cache`. These grow without bound since none of the
+tools prune them; to reset one, run `docker volume rm <name>`.
 
 ### Using pre-commit Locally to run Github Workflow checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ plain shell in the container.
 
 The `uv` package cache, Bazel's downloaded dependency archives, and pre-commit's
 environment cache persist across sandbox runs in Docker named volumes,
-`cc-protocol-uv-cache`, `cc-protocol-bazel-cache`, and
+`cc-protocol-uv-cache`, `cc-protocol-bazel-repository-cache`, and
 `cc-protocol-pre-commit-cache`. These grow without bound since none of the
 tools prune them; to reset one, run `docker volume rm <name>`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,11 +233,10 @@ plain shell in the container.
 | `--cache-volumes`, `--no-cache-volumes` | Mount the persistent cache volumes (default: on). |
 | `-v`, `--verbose` | Enable verbose logging. |
 
-The `uv` package cache, Bazel's downloaded dependency archives, and pre-commit's
-environment cache persist across sandbox runs in Docker named volumes,
-`cc-protocol-uv-cache`, `cc-protocol-bazel-repository-cache`, and
-`cc-protocol-pre-commit-cache`. These grow without bound since none of the
-tools prune them; to reset one, run `docker volume rm <name>`.
+The `uv` package cache and Bazel's downloaded dependency archives persist
+across sandbox runs in Docker named volumes, `cc-protocol-uv-cache` and
+`cc-protocol-bazel-repository-cache`. These grow without bound since neither
+tool prunes them; to reset one, run `docker volume rm <name>`.
 
 ### Using pre-commit Locally to run Github Workflow checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,10 +233,10 @@ plain shell in the container.
 | `--cache-volumes`, `--no-cache-volumes` | Mount the persistent cache volumes (default: on). |
 | `-v`, `--verbose` | Enable verbose logging. |
 
-The `uv` package cache and Bazel's downloaded dependency archives persist
-across sandbox runs in Docker named volumes, `cc-protocol-uv-cache` and
-`cc-protocol-bazel-repository-cache`. These grow without bound since neither
-tool prunes them; to reset one, run `docker volume rm <name>`.
+The `uv` package cache and Bazel's repository cache persist across sandbox runs
+in Docker named volumes, `cc-protocol-uv-cache` and
+`cc-protocol-bazel-repository-cache`. To reset either volume, run `docker volume
+rm <name>`.
 
 ### Using pre-commit Locally to run Github Workflow checks
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -144,4 +144,6 @@ ENV XYZ_BAZEL_REPOSITORY_CACHE_DIR="/home/vscode/.cache/bazel-repo"
 # into a root-owned directory.
 RUN mkdir -p "$UV_CACHE_DIR" "$XYZ_BAZEL_REPOSITORY_CACHE_DIR"
 
-RUN echo "common --repository_cache=$XYZ_BAZEL_REPOSITORY_CACHE_DIR" > /home/vscode/.bazelrc
+# repository_cache is defined in the sandbox user-directory config, not workspace config so only
+# the sandbox uses the respository cache.
+RUN echo "common --repository_cache=$XYZ_BAZEL_REPOSITORY_CACHE_DIR" >> /home/vscode/.bazelrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -137,7 +137,10 @@ FROM base AS sandbox
 # uv must copy files as the cache volume is on a different filesystem.
 ENV UV_LINK_MODE="copy"
 
+ENV BAZEL_CACHE_DIR="/home/vscode/.cache/bazel-repo"
+ENV PRE_COMMIT_HOME="/home/vscode/.cache/pre-commit"
+
 # Pre-create the cache dirs owned by vscode: Docker otherwise creates a
 # volume's mount point as root on first use, and these tools cannot write
 # into a root-owned directory.
-RUN mkdir -p "$UV_CACHE_DIR"
+RUN mkdir -p "$UV_CACHE_DIR" "$BAZEL_CACHE_DIR" "$PRE_COMMIT_HOME"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -138,9 +138,8 @@ FROM base AS sandbox
 ENV UV_LINK_MODE="copy"
 
 ENV BAZEL_REPOSITORY_CACHE_DIR="/home/vscode/.cache/bazel-repo"
-ENV PRE_COMMIT_HOME="/home/vscode/.cache/pre-commit"
 
 # Pre-create the cache dirs owned by vscode: Docker otherwise creates a
 # volume's mount point as root on first use, and these tools cannot write
 # into a root-owned directory.
-RUN mkdir -p "$UV_CACHE_DIR" "$BAZEL_REPOSITORY_CACHE_DIR" "$PRE_COMMIT_HOME"
+RUN mkdir -p "$UV_CACHE_DIR" "$BAZEL_REPOSITORY_CACHE_DIR"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -137,11 +137,11 @@ FROM base AS sandbox
 # uv must copy files as the cache volume is on a different filesystem.
 ENV UV_LINK_MODE="copy"
 
-ENV BAZEL_REPOSITORY_CACHE_DIR="/home/vscode/.cache/bazel-repo"
+ENV XYZ_BAZEL_REPOSITORY_CACHE_DIR="/home/vscode/.cache/bazel-repo"
 
 # Pre-create the cache dirs owned by vscode: Docker otherwise creates a
 # volume's mount point as root on first use, and these tools cannot write
 # into a root-owned directory.
-RUN mkdir -p "$UV_CACHE_DIR" "$BAZEL_REPOSITORY_CACHE_DIR"
+RUN mkdir -p "$UV_CACHE_DIR" "$XYZ_BAZEL_REPOSITORY_CACHE_DIR"
 
-RUN echo "common --repository_cache=$BAZEL_REPOSITORY_CACHE_DIR" > /home/vscode/.bazelrc
+RUN echo "common --repository_cache=$XYZ_BAZEL_REPOSITORY_CACHE_DIR" > /home/vscode/.bazelrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -143,3 +143,5 @@ ENV BAZEL_REPOSITORY_CACHE_DIR="/home/vscode/.cache/bazel-repo"
 # volume's mount point as root on first use, and these tools cannot write
 # into a root-owned directory.
 RUN mkdir -p "$UV_CACHE_DIR" "$BAZEL_REPOSITORY_CACHE_DIR"
+
+RUN echo "common --repository_cache=$BAZEL_REPOSITORY_CACHE_DIR" > /home/vscode/.bazelrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -137,10 +137,10 @@ FROM base AS sandbox
 # uv must copy files as the cache volume is on a different filesystem.
 ENV UV_LINK_MODE="copy"
 
-ENV BAZEL_CACHE_DIR="/home/vscode/.cache/bazel-repo"
+ENV BAZEL_REPOSITORY_CACHE_DIR="/home/vscode/.cache/bazel-repo"
 ENV PRE_COMMIT_HOME="/home/vscode/.cache/pre-commit"
 
 # Pre-create the cache dirs owned by vscode: Docker otherwise creates a
 # volume's mount point as root on first use, and these tools cannot write
 # into a root-owned directory.
-RUN mkdir -p "$UV_CACHE_DIR" "$BAZEL_CACHE_DIR" "$PRE_COMMIT_HOME"
+RUN mkdir -p "$UV_CACHE_DIR" "$BAZEL_REPOSITORY_CACHE_DIR" "$PRE_COMMIT_HOME"

--- a/scripts/agentic-sandbox.py
+++ b/scripts/agentic-sandbox.py
@@ -15,7 +15,11 @@ IMAGE_NAME = "cc-protocol-sandbox"
 
 # Docker named volumes persisting each tool's cache across container instances.
 # The devcontainer is long-lived and does not use these, it keeps its cache locally.
-CACHE_VOLUMES: dict[str, str] = {"cc-protocol-uv-cache": "/home/vscode/.cache/uv"}
+CACHE_VOLUMES: dict[str, str] = {
+    "cc-protocol-uv-cache": "/home/vscode/.cache/uv",
+    "cc-protocol-bazel-cache": "/home/vscode/.cache/bazel-repo",
+    "cc-protocol-pre-commit-cache": "/home/vscode/.cache/pre-commit",
+}
 
 
 class AgentCli(TypedDict):
@@ -127,7 +131,7 @@ def main() -> None:
         "--cache-volumes",
         action=argparse.BooleanOptionalAction,
         default=True,
-        help="Mount the persistent uv cache volumes.",
+        help="Mount the persistent cache volumes.",
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable verbose logging."

--- a/scripts/agentic-sandbox.py
+++ b/scripts/agentic-sandbox.py
@@ -15,6 +15,7 @@ IMAGE_NAME = "cc-protocol-sandbox"
 
 # Docker named volumes persisting each tool's cache across container instances.
 # The devcontainer is long-lived and does not use these, it keeps its cache locally.
+# Note: Cache paths must match those set in docker/Dockerfile.
 CACHE_VOLUMES: dict[str, str] = {
     "cc-protocol-uv-cache": "/home/vscode/.cache/uv",
     "cc-protocol-bazel-repository-cache": "/home/vscode/.cache/bazel-repo",

--- a/scripts/agentic-sandbox.py
+++ b/scripts/agentic-sandbox.py
@@ -17,7 +17,7 @@ IMAGE_NAME = "cc-protocol-sandbox"
 # The devcontainer is long-lived and does not use these, it keeps its cache locally.
 CACHE_VOLUMES: dict[str, str] = {
     "cc-protocol-uv-cache": "/home/vscode/.cache/uv",
-    "cc-protocol-bazel-cache": "/home/vscode/.cache/bazel-repo",
+    "cc-protocol-bazel-repository-cache": "/home/vscode/.cache/bazel-repo",
     "cc-protocol-pre-commit-cache": "/home/vscode/.cache/pre-commit",
 }
 

--- a/scripts/agentic-sandbox.py
+++ b/scripts/agentic-sandbox.py
@@ -18,7 +18,6 @@ IMAGE_NAME = "cc-protocol-sandbox"
 CACHE_VOLUMES: dict[str, str] = {
     "cc-protocol-uv-cache": "/home/vscode/.cache/uv",
     "cc-protocol-bazel-repository-cache": "/home/vscode/.cache/bazel-repo",
-    "cc-protocol-pre-commit-cache": "/home/vscode/.cache/pre-commit",
 }
 
 


### PR DESCRIPTION
With a populated cache, bazel builds can complete in the agentic sandbox with no internet connection.

See: https://bazel.build/run/build#repository-cache

NOTE: Syncing past this change needs the agentic sandbox to be run with `--rebuild-docker`.