### PR TITLE
Mark /workspace as a safe directory for git in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,3 +117,7 @@ ENV UV_PROJECT_ENVIRONMENT="/home/vscode/.venv"
 # Agent config dirs (~/.gemini / ~/.claude) are mounted from the host at runtime
 # to persist auth state between sessions. Default config files are seeded by the launch
 # script before the mount, so image-side preconfiguration is not needed here.
+
+# Avoid dubious ownership issues flagged by recent versions of git by trusting `/workspace`.
+# https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory
+RUN git config --global --add safe.directory /workspace


### PR DESCRIPTION
Fixes #307 