### PR TITLE
Save the Bazel disk cache on every CI run

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -141,10 +141,46 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
+          # The disk cache is not setup-bazel's `disk-cache`: that saves only
+          # when its key, a hash of the BUILD files, misses, so it froze at its
+          # first contents and every later run recompiled the same files. The
+          # restore and save steps below manage the directory instead, and
+          # Bazel's garbage collector bounds what each run carries forward.
+          # The collector is an idle task, so a zero delay lets it run as soon
+          # as the test command returns.
+          bazelrc: |
+            build --disk_cache=~/.cache/bazel-disk
+            build --experimental_disk_cache_gc_max_size=512M
+            build --experimental_disk_cache_gc_idle_delay=0
+      - name: Restore the Bazel disk cache
+        if: needs.detect-changes.outputs.relevant != 'false'
+        id: disk-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/bazel-disk
+          # Every run saves under its own commit and restores the newest cache
+          # with a matching prefix, usually the previous run's. One cache per
+          # compiler: the entries would not be shared anyway, and parallel
+          # jobs saving under one key would race.
+          key: bazel-disk-cache-${{ runner.os }}-${{ matrix.settings.compiler.type }}-${{ github.sha }}
+          restore-keys: bazel-disk-cache-${{ runner.os }}-${{ matrix.settings.compiler.type }}-
       - name: Run Bazel
         if: needs.detect-changes.outputs.relevant != 'false'
         run: ./scripts/bazel.sh
+      - name: Wait for the disk-cache garbage collector
+        if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
+        # Shutting down the server waits for the idle-task garbage collector
+        # to finish, so the save below never archives a directory that is
+        # still being trimmed.
+        run: bazel shutdown
+      - name: Save the Bazel disk cache
+        # Save after a failed build too: its objects are as good as any. Skip
+        # when the exact key already existed, which happens on a rerun.
+        if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' && steps.disk-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/bazel-disk
+          key: ${{ steps.disk-cache.outputs.cache-primary-key }}
 
   # This non-matrix job reports under a fixed name whatever the matrix above
   # did, so the ruleset can require one check per workflow instead of every

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -104,9 +104,29 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          # One disk cache per sanitizer: the two jobs would otherwise race
-          # to save under the same key and one of them would lose.
-          disk-cache: ${{ github.workflow }}-${{ matrix.sanitizer }}
+          # The disk cache is not setup-bazel's `disk-cache`: that saves only
+          # when its key, a hash of the BUILD files, misses, so it froze at its
+          # first contents and every later run recompiled the same files. The
+          # restore and save steps below manage the directory instead, and
+          # Bazel's garbage collector bounds what each run carries forward.
+          # The collector is an idle task, so a zero delay lets it run as soon
+          # as the test command returns.
+          bazelrc: |
+            build --disk_cache=~/.cache/bazel-disk
+            build --experimental_disk_cache_gc_max_size=512M
+            build --experimental_disk_cache_gc_idle_delay=0
+      - name: Restore the Bazel disk cache
+        if: needs.detect-changes.outputs.relevant != 'false'
+        id: disk-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/bazel-disk
+          # Every run saves under its own commit and restores the newest cache
+          # with a matching prefix, usually the previous run's. One cache per
+          # sanitizer: the entries would not be shared anyway, and parallel
+          # jobs saving under one key would race.
+          key: bazel-disk-cache-${{ runner.os }}-${{ matrix.sanitizer }}-${{ github.sha }}
+          restore-keys: bazel-disk-cache-${{ runner.os }}-${{ matrix.sanitizer }}-
       - name: Run Bazel
         if: needs.detect-changes.outputs.relevant != 'false'
         run: |
@@ -115,6 +135,20 @@ jobs:
             UBSAN_FLAG="--ubsan"
           fi
           ./scripts/bazel.sh --${{ matrix.sanitizer }} ${UBSAN_FLAG}
+      - name: Wait for the disk-cache garbage collector
+        if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' }}
+        # Shutting down the server waits for the idle-task garbage collector
+        # to finish, so the save below never archives a directory that is
+        # still being trimmed.
+        run: bazel shutdown
+      - name: Save the Bazel disk cache
+        # Save after a failed build too: its objects are as good as any. Skip
+        # when the exact key already existed, which happens on a rerun.
+        if: ${{ !cancelled() && needs.detect-changes.outputs.relevant != 'false' && steps.disk-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/bazel-disk
+          key: ${{ steps.disk-cache.outputs.cache-primary-key }}
 
   # This non-matrix job reports under a fixed name whatever the matrix above
   # did, so the ruleset can require one check per workflow instead of every


### PR DESCRIPTION
setup-bazel's `disk-cache` saves only when its key, a hash of the BUILD files, misses, so the cache froze at its first contents and every later run recompiled the same files.

Manage the directory with `actions/cache` instead: each Bazel and Sanitizers job restores the newest cache for its compiler or sanitizer and saves under its own commit. Bazel's disk-cache garbage collector, run as soon as the test command returns, keeps each cache under 512M.

### Measurements

`Run Bazel` step time and Bazel's own process summary, for the latest scheduled runs on main ([Bazel](https://github.com/jbcoe/cc-protocol/actions/runs/34190576328), [Sanitizers](https://github.com/jbcoe/cc-protocol/actions/runs/34191927160)), this PR's first run with no cache to restore, and a rerun of the same commit that restored what the first run saved ([Bazel](https://github.com/jbcoe/cc-protocol/actions/runs/34272039168), [Sanitizers](https://github.com/jbcoe/cc-protocol/actions/runs/34272039209)).

| Job | main, setup-bazel cache | This PR, cold | This PR, warm |
|---|---|---|---|
| GCC trunk | 78 s, 42 sandboxed, 0 hits | 68 s, 42 sandboxed, 0 hits | 17 s, 42 hits |
| GCC-16 | 50 s, 42 sandboxed, 0 hits | 59 s, 42 sandboxed, 0 hits | 18 s, 42 hits |
| asan | 122 s, 42 sandboxed, 0 hits | 107 s, 42 sandboxed, 0 hits | 16 s, 42 hits |
| tsan | 105 s, 42 sandboxed, 0 hits | 92 s, 42 sandboxed, 0 hits | 15 s, 42 hits |

The main runs did restore setup-bazel's cache, but it yielded no hits: its contents were compiled by an earlier GCC snapshot, and `scripts/bazel.py` stamps the compiler version into every action key. The saved caches are 2 MB (GCC trunk and GCC-16), 16 MB (asan) and 10 MB (tsan) compressed; restore and save each take about a second, and the garbage-collector wait under two.

Closes #298
