### PR TITLE
Test implicit protocol_view conversion at call sites

### DIFF
--- a/protocol_test.cc
+++ b/protocol_test.cc
@@ -2523,4 +2523,47 @@ TEST(ReflectionProtocolViewTest, ViewOfProtocolPassedByValue) {
   EXPECT_EQ(read(p), 5);
 }
 
+TEST(ReflectionProtocolViewTest, MutableViewOfProtocolPassedByValue) {
+  struct Interface {
+    int get() const;
+    void update(int value);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void update(int new_value) { value = new_value; }
+  };
+
+  auto write = [](protocol_view<Interface> view) { view.update(9); };
+
+  protocol<Interface> p(Conforming{});
+  write(p);
+  EXPECT_EQ(p.get(), 9);
+}
+
+TEST(ReflectionProtocolViewTest, ViewOfConformingObjectPassedByValue) {
+  struct Interface {
+    int get() const;
+    void update(int value);
+  };
+
+  struct Conforming {
+    int value = 0;
+
+    int get() const { return value; }
+
+    void update(int new_value) { value = new_value; }
+  };
+
+  auto read = [](protocol_view<const Interface> view) { return view.get(); };
+  auto write = [](protocol_view<Interface> view) { view.update(4); };
+
+  Conforming c{};
+  write(c);
+  EXPECT_EQ(read(c), 4);
+}
+
 }  // namespace


### PR DESCRIPTION
#272 made `protocol_view<T>` and `protocol_view<const T>` implicitly constructible, which is what #270 asks for, and the issue's own test landed in #244. This adds the sibling call sites: a mutable view from a `protocol` lvalue, and both views from a conforming object lvalue, each passed by value to a function.

Closes #270
