### PR TITLE
Bake the googletest checkout into the sandbox image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,6 +253,10 @@ in Docker named volumes, `cc-protocol-uv-cache` and
 `cc-protocol-bazel-repository-cache`. To reset either volume, run `docker volume
 rm <name>`.
 
+The sandbox image also carries a googletest checkout at the tag pinned in
+`CMakeLists.txt`, so CMake builds need no network. Bumping that tag needs
+`--rebuild-docker`, as for `.bazelversion`.
+
 ### Using pre-commit Locally to run Github Workflow checks
 
 Install pre-commit hooks into your local repository:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -147,3 +147,11 @@ RUN mkdir -p "$UV_CACHE_DIR" "$XYZ_BAZEL_REPOSITORY_CACHE_DIR"
 # repository_cache is defined in the sandbox user-directory config, not workspace config so only
 # the sandbox uses the respository cache.
 RUN echo "common --repository_cache=$XYZ_BAZEL_REPOSITORY_CACHE_DIR" >> /home/vscode/.bazelrc
+
+# Bake the googletest checkout into the image so CMake builds need no network.
+# With FETCHCONTENT_SOURCE_DIR_GOOGLETEST set, FetchContent performs no download
+# or update step and each build tree still compiles its own copy. The tag must
+# match GIT_TAG in CMakeLists.txt; bumping it needs --rebuild-docker.
+ENV FETCHCONTENT_SOURCE_DIR_GOOGLETEST="/home/vscode/.cache/googletest-src"
+RUN git clone --depth 1 --branch v1.18.0 https://github.com/google/googletest.git \
+    "$FETCHCONTENT_SOURCE_DIR_GOOGLETEST"

--- a/scripts/cmake.py
+++ b/scripts/cmake.py
@@ -168,6 +168,12 @@ def main() -> None:
         f"-DENABLE_TSAN={'ON' if args.tsan else 'OFF'}",
         f"-DENABLE_COVERAGE={'ON' if args.coverage else 'OFF'}",
         f"-DCLANG_TIDY_ENABLE={'ON' if args.clang_tidy else 'OFF'}",
+        # The sandbox image sets this to its baked-in googletest checkout.
+        # Passed on every configure, empty elsewhere, so a build directory
+        # shared between the sandbox and the devcontainer never keeps a
+        # stale value.
+        "-DFETCHCONTENT_SOURCE_DIR_GOOGLETEST="
+        + os.environ.get("FETCHCONTENT_SOURCE_DIR_GOOGLETEST", ""),
         "-B",
         args.build_dir,
     ]

--- a/scripts/consteval_coverage.py
+++ b/scripts/consteval_coverage.py
@@ -329,9 +329,16 @@ class Instrumenter:
 
 
 def find_googletest_include_directories() -> list[str]:
-    """Locate googletest headers under an existing CMake build directory."""
+    """
+    Locate googletest headers in the checkout CMake used.
+
+    The sandbox image points FETCHCONTENT_SOURCE_DIR_GOOGLETEST at a baked-in
+    checkout; elsewhere FetchContent clones under the build directory.
+    """
     pattern = os.path.join(SOURCE_ROOT, "build", "*", "_deps", "googletest-src")
-    for googletest_source in sorted(glob.glob(pattern)):
+    candidates = [os.environ.get("FETCHCONTENT_SOURCE_DIR_GOOGLETEST", "")]
+    candidates += sorted(glob.glob(pattern))
+    for googletest_source in filter(None, candidates):
         include_directories = [
             os.path.join(googletest_source, "googletest", "include"),
             os.path.join(googletest_source, "googlemock", "include"),


### PR DESCRIPTION
Follow-up to #315.

The sandbox image clones googletest at the tag pinned in `CMakeLists.txt` and sets `FETCHCONTENT_SOURCE_DIR_GOOGLETEST` to it. With that variable set FetchContent performs no download or update step, so CMake builds in the sandbox need no network, and each build tree still compiles its own copy. The checkout is image content: nothing to lock, stamp or invalidate. Bumping the tag is a Dockerfile edit plus `--rebuild-docker`, as for `.bazelversion`.

`cmake.py` forwards the variable on every configure, empty outside the sandbox, so a build directory shared between the sandbox and the devcontainer picks up the right value each time. `consteval_coverage.py` checks the same variable before the build tree's own `_deps`.

No `CMakeLists.txt` change and no new volume.

NOTE: Syncing past this change needs the agentic sandbox to be run with `--rebuild-docker`.
