### PR TITLE
Add docker-in-docker to the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,12 @@
 		"context": "..",
 		"target": "base"
 	},
+	// A Docker daemon inside the container, so the agentic sandbox image can be
+	// built and run from the devcontainer, including in Codespaces, which has
+	// no host Docker socket to share.
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
 	"remoteUser": "vscode",
 	// Host credentials are shared with the container by bind-mounting them into
 	// the `vscode` home directory. Only `~/.ssh` is mounted by default. To reuse


### PR DESCRIPTION
Adds the docker-in-docker devcontainer feature. Codespaces has no host Docker socket to share, so the feature runs its own daemon inside the devcontainer. That makes `./scripts/agentic-sandbox.sh --rebuild-docker` runnable from the devcontainer, so a `docker/Dockerfile` change such as #330 can be built and checked before it lands.

Needs a devcontainer rebuild to take effect.
