### PR TITLE
Revert "Add docker-in-docker to the devcontainer"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,12 +5,6 @@
 		"context": "..",
 		"target": "base"
 	},
-	// A Docker daemon inside the container, so the agentic sandbox image can be
-	// built and run from the devcontainer, including in Codespaces, which has
-	// no host Docker socket to share.
-	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
-	},
 	"remoteUser": "vscode",
 	// Host credentials are shared with the container by bind-mounting them into
 	// the `vscode` home directory. Only `~/.ssh` is mounted by default. To reuse


### PR DESCRIPTION
Reverts jbcoe/cc-protocol#332 as it fails to build a devcontainer on codespaces