### PR TITLE
Add macOS CI jobs for Bazel and CMake builds

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -81,6 +81,7 @@ jobs:
     if: ${{ !cancelled() }}
     name: ${{ matrix.settings.name }}
     runs-on: ${{ matrix.settings.os }}
+    continue-on-error: ${{ matrix.settings.compiler.type == 'GCC16_MACOS' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -114,6 +114,21 @@ jobs:
                   std: 26,
                 },
             }
+          # Neither the GCC trunk snapshot (a .deb) nor Ubuntu's gcc-16
+          # package is available on macOS, so this job gets its reflection
+          # compiler from the gcc@16 Homebrew formula instead.
+          - {
+              name: "GCC-16 (macOS)",
+              os: macos-15,
+              compiler:
+                {
+                  type: GCC16_MACOS,
+                  version: 16,
+                  cc: "gcc-16",
+                  cxx: "g++-16",
+                  std: 26,
+                },
+            }
     steps:
       - uses: actions/checkout@v5
         if: needs.detect-changes.outputs.relevant != 'false'
@@ -130,6 +145,12 @@ jobs:
           sudo apt-get install -y --no-install-recommends gcc-16 g++-16
           echo "CXX=$(which ${{ matrix.settings.compiler.cxx }})" >> "$GITHUB_ENV"
           echo "CC=$(which ${{ matrix.settings.compiler.cc }})" >> "$GITHUB_ENV"
+      - name: Install GCC 16 (macOS)
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC16_MACOS'
+        run: |
+          brew install gcc@16
+          echo "CXX=$(brew --prefix gcc@16)/bin/${{ matrix.settings.compiler.cxx }}" >> "$GITHUB_ENV"
+          echo "CC=$(brew --prefix gcc@16)/bin/${{ matrix.settings.compiler.cc }}" >> "$GITHUB_ENV"
       - name: Install uv
         if: needs.detect-changes.outputs.relevant != 'false'
         uses: astral-sh/setup-uv@v10.0.1

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -107,6 +107,21 @@ jobs:
                   std: 26,
                 },
             }
+          # Neither the GCC trunk snapshot (a .deb) nor Ubuntu's gcc-16
+          # package is available on macOS, so this job gets its reflection
+          # compiler from the gcc@16 Homebrew formula instead.
+          - {
+              name: "GCC-16 (macOS)",
+              os: macos-15,
+              compiler:
+                {
+                  type: GCC16_MACOS,
+                  version: 16,
+                  cc: "gcc-16",
+                  cxx: "g++-16",
+                  std: 26,
+                },
+            }
     steps:
       - uses: actions/checkout@v5
         if: needs.detect-changes.outputs.relevant != 'false'
@@ -125,6 +140,12 @@ jobs:
           sudo apt-get install -y --no-install-recommends gcc-16 g++-16
           echo "CXX=${{ matrix.settings.compiler.cxx }}" >> "$GITHUB_ENV"
           echo "CC=${{ matrix.settings.compiler.cc }}" >> "$GITHUB_ENV"
+      - name: Install GCC 16 (macOS)
+        if: needs.detect-changes.outputs.relevant != 'false' && matrix.settings.compiler.type == 'GCC16_MACOS'
+        run: |
+          brew install gcc@16
+          echo "CXX=$(brew --prefix gcc@16)/bin/${{ matrix.settings.compiler.cxx }}" >> "$GITHUB_ENV"
+          echo "CC=$(brew --prefix gcc@16)/bin/${{ matrix.settings.compiler.cc }}" >> "$GITHUB_ENV"
       - name: Install uv
         if: needs.detect-changes.outputs.relevant != 'false'
         uses: astral-sh/setup-uv@v10.0.1

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,6 +73,7 @@ jobs:
     if: ${{ !cancelled() }}
     name: ${{ matrix.settings.name }} ${{ matrix.configuration }}
     runs-on: ${{ matrix.settings.os }}
+    continue-on-error: ${{ matrix.settings.compiler.type == 'GCC16_MACOS' }}
     strategy:
       fail-fast: false
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,26 +76,32 @@ endif()
 # LD_LIBRARY_PATH set.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   execute_process(
-    COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libstdc++.so
+    COMMAND ${CMAKE_CXX_COMPILER}
+            -print-file-name=libstdc++${CMAKE_SHARED_LIBRARY_SUFFIX}
     OUTPUT_VARIABLE XYZ_PROTOCOL_LIBSTDCXX_PATH
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  get_filename_component(XYZ_PROTOCOL_LIBSTDCXX_PATH
-                          "${XYZ_PROTOCOL_LIBSTDCXX_PATH}" REALPATH)
-  get_filename_component(XYZ_PROTOCOL_LIBSTDCXX_DIRECTORY
-                          "${XYZ_PROTOCOL_LIBSTDCXX_PATH}" DIRECTORY)
-  list(APPEND CMAKE_BUILD_RPATH "${XYZ_PROTOCOL_LIBSTDCXX_DIRECTORY}")
+  if(EXISTS "${XYZ_PROTOCOL_LIBSTDCXX_PATH}")
+    get_filename_component(XYZ_PROTOCOL_LIBSTDCXX_PATH
+                           "${XYZ_PROTOCOL_LIBSTDCXX_PATH}" REALPATH)
+    get_filename_component(XYZ_PROTOCOL_LIBSTDCXX_DIRECTORY
+                           "${XYZ_PROTOCOL_LIBSTDCXX_PATH}" DIRECTORY)
+    list(APPEND CMAKE_BUILD_RPATH "${XYZ_PROTOCOL_LIBSTDCXX_DIRECTORY}")
+  endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # Same for the clang-p2996 fork's libc++, which lives in the fork's build
   # tree rather than a directory ld.so searches.
   execute_process(
-    COMMAND ${CMAKE_CXX_COMPILER} -print-file-name=libc++.so
+    COMMAND ${CMAKE_CXX_COMPILER}
+            -print-file-name=libc++${CMAKE_SHARED_LIBRARY_SUFFIX}
     OUTPUT_VARIABLE XYZ_PROTOCOL_LIBCXX_PATH
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  get_filename_component(XYZ_PROTOCOL_LIBCXX_PATH
-                          "${XYZ_PROTOCOL_LIBCXX_PATH}" REALPATH)
-  get_filename_component(XYZ_PROTOCOL_LIBCXX_DIRECTORY
-                          "${XYZ_PROTOCOL_LIBCXX_PATH}" DIRECTORY)
-  list(APPEND CMAKE_BUILD_RPATH "${XYZ_PROTOCOL_LIBCXX_DIRECTORY}")
+  if(EXISTS "${XYZ_PROTOCOL_LIBCXX_PATH}")
+    get_filename_component(XYZ_PROTOCOL_LIBCXX_PATH
+                           "${XYZ_PROTOCOL_LIBCXX_PATH}" REALPATH)
+    get_filename_component(XYZ_PROTOCOL_LIBCXX_DIRECTORY
+                           "${XYZ_PROTOCOL_LIBCXX_PATH}" DIRECTORY)
+    list(APPEND CMAKE_BUILD_RPATH "${XYZ_PROTOCOL_LIBCXX_DIRECTORY}")
+  endif()
 endif()
 
 if(ENABLE_ASAN OR ENABLE_UBSAN OR ENABLE_TSAN)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,9 @@ release pinned in `.bazelversion` on first use), a GCC with C++26 reflection
 (P2996) support, and
 [uv](https://docs.astral.sh/uv/getting-started/installation/) installed. The
 reflection compiler is either the GCC trunk snapshot from
-[jwakely.github.io/pkg-gcc-latest](https://jwakely.github.io/pkg-gcc-latest/)
-or Ubuntu 26.04's `gcc-16` package. The project relies on `uv` to manage
+[jwakely.github.io/pkg-gcc-latest](https://jwakely.github.io/pkg-gcc-latest/),
+Ubuntu 26.04's `gcc-16` package, or Homebrew's `gcc@16` formula on macOS
+(`brew install gcc@16`). The project relies on `uv` to manage
 Python dependencies and execute build scripts. The CMake build, used for
 coverage and clang-tidy, additionally needs
 [CMake](https://cmake.org/download/) 3.25 or later. To move to a newer Bazel
@@ -71,6 +72,8 @@ fails on stock GCC.
 Pull requests run the workflows in `.github/workflows`. The following checks
 are required for merging to `main`: `GCC trunk Release`, `GCC trunk Debug`,
 `GCC-16 Release`, `GCC-16 Debug`, `asan`, `tsan`, `uv-lock`, `pre-commit`.
+The workflows also run advisory macOS jobs (`GCC-16 (macOS)` in Bazel, and
+`GCC-16 (macOS) Release` and `GCC-16 (macOS) Debug` in CMake).
 
 On pull requests that touch no C++, CMake, Bazel, or build-script sources,
 a change-detection job makes the build and sanitizer jobs skip their steps,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ The instructions the assistants read are in [AGENTS.md](AGENTS.md);
 ./scripts/agentic-sandbox.sh [agent] [options]
 ```
 
-where `agent` is `claude`, `gemini`, or `agy` (Antigravity). Omit it for a
+where `agent` is `claude` or `agy` (Antigravity). Omit it for a
 plain shell in the container.
 
 ### Options

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -7,44 +7,58 @@ if(ENABLE_SANITIZERS)
 
   include(CheckCXXCompilerFlag)
 
-  # Check ASAN
-  set(CMAKE_REQUIRED_FLAGS "-fsanitize=address -fno-omit-frame-pointer")
-  set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=address")
-  check_cxx_compiler_flag("-fsanitize=address" COMPILER_SUPPORTS_ASAN)
-
-  # Check UBSAN
-  set(CMAKE_REQUIRED_FLAGS "-fsanitize=undefined")
-  set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=undefined")
-  check_cxx_compiler_flag("-fsanitize=undefined" COMPILER_SUPPORTS_UBSAN)
-
-  # Check TSAN
-  set(CMAKE_REQUIRED_FLAGS "-fsanitize=thread")
-  set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=thread")
-  check_cxx_compiler_flag("-fsanitize=thread" COMPILER_SUPPORTS_TSAN)
-
-
-  # Reset required flags
-  unset(CMAKE_REQUIRED_FLAGS)
-  unset(CMAKE_REQUIRED_LINK_OPTIONS)
-
-  if(COMPILER_SUPPORTS_ASAN)
+  if(ENABLE_ASAN)
+    # Check ASAN
+    set(CMAKE_REQUIRED_FLAGS "-fsanitize=address -fno-omit-frame-pointer")
+    set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=address")
+    check_cxx_compiler_flag("-fsanitize=address" COMPILER_SUPPORTS_ASAN)
+    if(NOT COMPILER_SUPPORTS_ASAN)
+      message(
+        FATAL_ERROR
+          "AddressSanitizer is requested (ENABLE_ASAN=ON) but not supported by the compiler (${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION})."
+      )
+    endif()
     add_library(asan INTERFACE IMPORTED)
     set_target_properties(
       asan PROPERTIES INTERFACE_COMPILE_OPTIONS "${SANITIZER_FLAGS_ASAN}"
                       INTERFACE_LINK_OPTIONS "${SANITIZER_FLAGS_ASAN}")
-  endif(COMPILER_SUPPORTS_ASAN)
+  endif()
 
-  if(COMPILER_SUPPORTS_UBSAN)
+  if(ENABLE_UBSAN)
+    # Check UBSAN
+    set(CMAKE_REQUIRED_FLAGS "-fsanitize=undefined")
+    set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=undefined")
+    check_cxx_compiler_flag("-fsanitize=undefined" COMPILER_SUPPORTS_UBSAN)
+    if(NOT COMPILER_SUPPORTS_UBSAN)
+      message(
+        FATAL_ERROR
+          "UndefinedBehaviorSanitizer is requested (ENABLE_UBSAN=ON) but not supported by the compiler (${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION})."
+      )
+    endif()
     add_library(ubsan INTERFACE IMPORTED)
     set_target_properties(
       ubsan PROPERTIES INTERFACE_COMPILE_OPTIONS "${SANITIZER_FLAGS_UBSAN}"
                        INTERFACE_LINK_OPTIONS "${SANITIZER_FLAGS_UBSAN}")
-  endif(COMPILER_SUPPORTS_UBSAN)
+  endif()
 
-  if(COMPILER_SUPPORTS_TSAN)
+  if(ENABLE_TSAN)
+    # Check TSAN
+    set(CMAKE_REQUIRED_FLAGS "-fsanitize=thread")
+    set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=thread")
+    check_cxx_compiler_flag("-fsanitize=thread" COMPILER_SUPPORTS_TSAN)
+    if(NOT COMPILER_SUPPORTS_TSAN)
+      message(
+        FATAL_ERROR
+          "ThreadSanitizer is requested (ENABLE_TSAN=ON) but not supported by the compiler (${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION})."
+      )
+    endif()
     add_library(tsan INTERFACE IMPORTED)
     set_target_properties(
       tsan PROPERTIES INTERFACE_COMPILE_OPTIONS "${SANITIZER_FLAGS_TSAN}"
                       INTERFACE_LINK_OPTIONS "${SANITIZER_FLAGS_TSAN}")
-  endif(COMPILER_SUPPORTS_TSAN)
+  endif()
+
+  # Reset required flags
+  unset(CMAKE_REQUIRED_FLAGS)
+  unset(CMAKE_REQUIRED_LINK_OPTIONS)
 endif(ENABLE_SANITIZERS)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # Install the GitHub CLI (gh) from its own apt repository, per
 # https://github.com/cli/cli/blob/trunk/docs/install_linux.md (not reliably
-# available via Ubuntu 24.04's default repos).
+# available via Ubuntu 26.04's default repos).
 RUN mkdir -p -m 755 /etc/apt/keyrings \
     && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -64,7 +64,7 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 # Install jj (Jujutsu VCS) from its GitHub release binary. The jujutsu apt
-# package isn't built for Ubuntu 24.04 (noble) or Debian stable; it only
+# package isn't built for Ubuntu 26.04 (resolute) or Debian stable; it only
 # reaches Debian testing/unstable and Ubuntu's current development release.
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \
@@ -89,7 +89,7 @@ RUN userdel -r ubuntu \
     && mkdir -p /workspace \
     && chown vscode:vscode /workspace
 
-# Install Node.js (required for both Gemini CLI and Claude Code).
+# Install Node.js (required for Claude Code).
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
@@ -103,9 +103,8 @@ ENV NPM_CONFIG_PREFIX=/home/vscode/.npm-global
 ENV PATH="/home/vscode/.npm-global/bin:/home/vscode/.local/bin:/usr/local/bin:${PATH}"
 RUN mkdir -p /home/vscode/.npm-global
 
-# Install both AI agent CLIs for compatibility with existing tooling that
-# may invoke either `gemini` or `claude`.
-RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code
+# Install Claude Code CLI.
+RUN npm install -g @anthropic-ai/claude-code
 
 # Install Antigravity CLI (installs binary as `agy` into ~/.local/bin).
 RUN curl -fsSL https://antigravity.google/cli/install.sh | bash

--- a/scripts/agentic-sandbox.py
+++ b/scripts/agentic-sandbox.py
@@ -2,7 +2,7 @@
 """
 Script to run an AI agent, or a plain shell, in a Docker sandbox.
 
-Supported agents: Gemini CLI, Claude Code, Antigravity CLI.
+Supported agents: Claude Code, Antigravity CLI.
 """
 
 import argparse
@@ -30,7 +30,6 @@ class AgentCli(TypedDict):
 
 
 AGENT_CLIS: dict[str, AgentCli] = {
-    "gemini": {"npm_package": "@google/gemini-cli", "cmd": "gemini"},
     "claude": {
         "npm_package": "@anthropic-ai/claude-code",
         "cmd": "claude --dangerously-skip-permissions",
@@ -69,7 +68,7 @@ def _agent_mount_args(agent: str | None) -> list[str]:
     """Seed and mount host config so an agent CLI keeps its auth state."""
     # Use os.open with restrictive permissions in _seed_config_file to avoid
     # exposing credentials to other local users on multi-user systems.
-    if agent in ("gemini", "agy"):
+    if agent == "agy":
         gemini_config_dir = os.path.expanduser("~/.gemini")
         os.makedirs(gemini_config_dir, mode=0o700, exist_ok=True)
         _seed_config_file(
@@ -109,7 +108,7 @@ def _agent_mount_args(agent: str | None) -> list[str]:
 def main() -> None:
     """Provide the main entry point for the agentic sandbox script."""
     parser = argparse.ArgumentParser(
-        description="Run an AI agent (gemini, claude, or agy) in a Docker "
+        description="Run an AI agent (claude or agy) in a Docker "
         "sandbox, or a plain shell if no agent is given."
     )
     parser.add_argument(

--- a/scripts/compiler_discovery.py
+++ b/scripts/compiler_discovery.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from typing import Mapping
 from typing import Optional
 from typing import Tuple
@@ -37,21 +38,27 @@ def find_runtime_library_directory(cxx_compiler_path: str) -> Optional[str]:
     libc++ for Clang (the clang-p2996 fork keeps it in its own build tree),
     libstdc++ otherwise.
     """
+    shared_library_suffix = ".dylib" if sys.platform == "darwin" else ".so"
     if "clang" in os.path.basename(cxx_compiler_path):
-        return _find_library_directory(cxx_compiler_path, "libc++.so")
+        return _find_library_directory(
+            cxx_compiler_path, f"libc++{shared_library_suffix}"
+        )
     return find_libstdcxx_directory(cxx_compiler_path)
 
 
 def find_libstdcxx_directory(cxx_compiler_path: str) -> Optional[str]:
     """
-    Resolve the libstdc++.so directory for cxx_compiler_path.
+    Resolve the libstdc++ shared library directory for cxx_compiler_path.
 
     Mirrors the rpath lookup in CMakeLists.txt: a non-distro GCC keeps its
     libstdc++ in a directory ld.so does not search by default, so callers
     linking against it need this directory to run the result without
     LD_LIBRARY_PATH set.
     """
-    library_directory = _find_library_directory(cxx_compiler_path, "libstdc++.so")
+    shared_library_suffix = ".dylib" if sys.platform == "darwin" else ".so"
+    library_directory = _find_library_directory(
+        cxx_compiler_path, f"libstdc++{shared_library_suffix}"
+    )
     if library_directory is not None:
         return library_directory
 


### PR DESCRIPTION
Adds macOS jobs to the bazel.yml and cmake.yml matrices. 

Install the reflection compiler via Homebrew's gcc@16 formula, since the Linux jobs' compiler sources aren't available on macOS. 

No sanitizer jobs are added as sanitizer support on MacOS is limited.

Note: macOS jobs should not be made blocking as provisioning macOS action-runners on GitHub can be slow.