### PR TITLE
Fix stale Ubuntu 24.04 references in Dockerfile comments

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # Install the GitHub CLI (gh) from its own apt repository, per
 # https://github.com/cli/cli/blob/trunk/docs/install_linux.md (not reliably
-# available via Ubuntu 24.04's default repos).
+# available via Ubuntu 26.04's default repos).
 RUN mkdir -p -m 755 /etc/apt/keyrings \
     && wget -nv -O /etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -64,7 +64,7 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/*
 
 # Install jj (Jujutsu VCS) from its GitHub release binary. The jujutsu apt
-# package isn't built for Ubuntu 24.04 (noble) or Debian stable; it only
+# package isn't built for Ubuntu 26.04 (resolute) or Debian stable; it only
 # reaches Debian testing/unstable and Ubuntu's current development release.
 RUN ARCH=$(dpkg --print-architecture) && \
     case "$ARCH" in \


### PR DESCRIPTION
The gh and jj install comments still named Ubuntu 24.04 (noble) after the base image moved to 26.04 (resolute).