### PR TITLE
Remove Gemini as a coding agent option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ The instructions the assistants read are in [AGENTS.md](AGENTS.md);
 ./scripts/agentic-sandbox.sh [agent] [options]
 ```
 
-where `agent` is `claude`, `gemini`, or `agy` (Antigravity). Omit it for a
+where `agent` is `claude` or `agy` (Antigravity). Omit it for a
 plain shell in the container.
 
 ### Options

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,7 @@ RUN userdel -r ubuntu \
     && mkdir -p /workspace \
     && chown vscode:vscode /workspace
 
-# Install Node.js (required for both Gemini CLI and Claude Code).
+# Install Node.js (required for Claude Code).
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
@@ -103,9 +103,8 @@ ENV NPM_CONFIG_PREFIX=/home/vscode/.npm-global
 ENV PATH="/home/vscode/.npm-global/bin:/home/vscode/.local/bin:/usr/local/bin:${PATH}"
 RUN mkdir -p /home/vscode/.npm-global
 
-# Install both AI agent CLIs for compatibility with existing tooling that
-# may invoke either `gemini` or `claude`.
-RUN npm install -g @google/gemini-cli @anthropic-ai/claude-code
+# Install Claude Code CLI.
+RUN npm install -g @anthropic-ai/claude-code
 
 # Install Antigravity CLI (installs binary as `agy` into ~/.local/bin).
 RUN curl -fsSL https://antigravity.google/cli/install.sh | bash

--- a/scripts/agentic-sandbox.py
+++ b/scripts/agentic-sandbox.py
@@ -2,7 +2,7 @@
 """
 Script to run an AI agent, or a plain shell, in a Docker sandbox.
 
-Supported agents: Gemini CLI, Claude Code, Antigravity CLI.
+Supported agents: Claude Code, Antigravity CLI.
 """
 
 import argparse
@@ -30,7 +30,6 @@ class AgentCli(TypedDict):
 
 
 AGENT_CLIS: dict[str, AgentCli] = {
-    "gemini": {"npm_package": "@google/gemini-cli", "cmd": "gemini"},
     "claude": {
         "npm_package": "@anthropic-ai/claude-code",
         "cmd": "claude --dangerously-skip-permissions",
@@ -69,7 +68,7 @@ def _agent_mount_args(agent: str | None) -> list[str]:
     """Seed and mount host config so an agent CLI keeps its auth state."""
     # Use os.open with restrictive permissions in _seed_config_file to avoid
     # exposing credentials to other local users on multi-user systems.
-    if agent in ("gemini", "agy"):
+    if agent == "agy":
         gemini_config_dir = os.path.expanduser("~/.gemini")
         os.makedirs(gemini_config_dir, mode=0o700, exist_ok=True)
         _seed_config_file(
@@ -109,7 +108,7 @@ def _agent_mount_args(agent: str | None) -> list[str]:
 def main() -> None:
     """Provide the main entry point for the agentic sandbox script."""
     parser = argparse.ArgumentParser(
-        description="Run an AI agent (gemini, claude, or agy) in a Docker "
+        description="Run an AI agent (claude or agy) in a Docker "
         "sandbox, or a plain shell if no agent is given."
     )
     parser.add_argument(


### PR DESCRIPTION
Remove Gemini CLI as a supported coding agent option from docs, Dockerfile, and agentic-sandbox scripts.